### PR TITLE
Sync structured menu schema with data source

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -26,13 +26,14 @@
 </script>
 <script defer="" src="scripts/swRegister.js">
 </script>
-<script type="application/ld+json">
+<script id="menu-schema" type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "Menu",
   "@id": "https://sandgraal.github.io/gereni-menu/menu.html#menu",
   "name": "Menú principal",
   "inLanguage": "es-CR",
+  "url": "https://sandgraal.github.io/gereni-menu/menu.html",
   "isPartOf": {
     "@id": "https://sandgraal.github.io/gereni-menu/#restaurant"
   },
@@ -44,7 +45,9 @@
         {
           "@type": "MenuItem",
           "name": "Fajitas Mixtas",
+          "alternateName": "Mixed Fajitas",
           "description": "Acompañadas con papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "4800",
@@ -55,7 +58,9 @@
         {
           "@type": "MenuItem",
           "name": "Fajitas de Pollo o Carne",
+          "alternateName": "Chicken or Beef Fajitas",
           "description": "Acompañadas con papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "4500",
@@ -66,7 +71,9 @@
         {
           "@type": "MenuItem",
           "name": "Nuggets de Pollo",
+          "alternateName": "Chicken Nuggets",
           "description": "Acompañadas con papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "3700",
@@ -77,7 +84,9 @@
         {
           "@type": "MenuItem",
           "name": "Dedos de Pescado",
+          "alternateName": "Fish Sticks",
           "description": "Acompañados de papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "3500",
@@ -88,7 +97,9 @@
         {
           "@type": "MenuItem",
           "name": "Ceviche de Pescado",
+          "alternateName": "Fish Ceviche",
           "description": "Preparado fresco del día.",
+          "disambiguatingDescription": "Prepared fresh each day.",
           "offers": {
             "@type": "Offer",
             "price": "3000",
@@ -99,7 +110,9 @@
         {
           "@type": "MenuItem",
           "name": "Ceviche Mixto",
+          "alternateName": "Mixed Ceviche",
           "description": "Selección de mariscos del día.",
+          "disambiguatingDescription": "Chef's daily seafood selection.",
           "offers": {
             "@type": "Offer",
             "price": "3700",
@@ -110,7 +123,10 @@
         {
           "@type": "MenuItem",
           "name": "Sopa Azteca",
+          "alternateName": "Aztec Soup",
           "description": "Caldo tradicional con tortilla y queso.",
+          "disambiguatingDescription": "Traditional broth with tortilla and cheese.",
+          "image": "assets/photos/gustitos-sopa-azteca.png",
           "offers": {
             "@type": "Offer",
             "price": "4000",
@@ -121,7 +137,9 @@
         {
           "@type": "MenuItem",
           "name": "Sopa Negra",
+          "alternateName": "Black Bean Soup",
           "description": "Acompañada de arroz.",
+          "disambiguatingDescription": "Served with rice.",
           "offers": {
             "@type": "Offer",
             "price": "2000",
@@ -132,7 +150,9 @@
         {
           "@type": "MenuItem",
           "name": "Carne en Salsa",
+          "alternateName": "Beef in Sauce",
           "description": "Acompañada de arroz.",
+          "disambiguatingDescription": "Served with rice.",
           "offers": {
             "@type": "Offer",
             "price": "2500",
@@ -143,7 +163,9 @@
         {
           "@type": "MenuItem",
           "name": "Garbanzos / Frijoles Blancos / Pozol",
+          "alternateName": "Chickpeas / White Beans / Pozol",
           "description": "Porción casera del día.",
+          "disambiguatingDescription": "Homestyle portion of the day.",
           "offers": {
             "@type": "Offer",
             "price": "2000",
@@ -154,7 +176,9 @@
         {
           "@type": "MenuItem",
           "name": "Canelones",
+          "alternateName": "Cannelloni",
           "description": "2 unidades bañadas en salsa de tomate.",
+          "disambiguatingDescription": "Two pieces covered in tomato sauce.",
           "offers": {
             "@type": "Offer",
             "price": "1200",
@@ -162,7 +186,8 @@
             "availability": "https://schema.org/InStock"
           }
         }
-      ]
+      ],
+      "alternateName": "Starters"
     },
     {
       "@type": "MenuSection",
@@ -171,7 +196,10 @@
         {
           "@type": "MenuItem",
           "name": "Casados",
+          "alternateName": "Casados Plate",
           "description": "Con arroz, frijoles, picadillo, ensalada y una carne.",
+          "disambiguatingDescription": "Rice, beans, picadillo, salad, and your choice of protein.",
+          "image": "assets/photos/con-arroz-casados.png",
           "offers": {
             "@type": "Offer",
             "price": "3390",
@@ -182,7 +210,9 @@
         {
           "@type": "MenuItem",
           "name": "Casado Criollo",
+          "alternateName": "Criollo Casado",
           "description": "Arroz, frijoles, picadillo, ensalada, huevo, queso y refresco.",
+          "disambiguatingDescription": "Rice, beans, picadillo, salad, egg, cheese, and a drink.",
           "offers": {
             "@type": "Offer",
             "price": "2500",
@@ -193,7 +223,10 @@
         {
           "@type": "MenuItem",
           "name": "Arroz de la Casa",
+          "alternateName": "House Special Rice",
           "description": "Cerdo, pollo, camarones, chorizo, ensalada y papas.",
+          "disambiguatingDescription": "Pork, chicken, shrimp, chorizo, salad, and fries.",
+          "image": "assets/photos/con-arroz-arroz-de-la-casa.png",
           "offers": {
             "@type": "Offer",
             "price": "4750",
@@ -204,7 +237,9 @@
         {
           "@type": "MenuItem",
           "name": "Arroz con Pollo",
+          "alternateName": "Chicken Rice",
           "description": "Acompañado de papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "3995",
@@ -215,7 +250,9 @@
         {
           "@type": "MenuItem",
           "name": "Arroz con Camarones",
+          "alternateName": "Shrimp Rice",
           "description": "Acompañado de papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "4520",
@@ -223,7 +260,8 @@
             "availability": "https://schema.org/InStock"
           }
         }
-      ]
+      ],
+      "alternateName": "With Rice"
     },
     {
       "@type": "MenuSection",
@@ -233,6 +271,8 @@
           "@type": "MenuItem",
           "name": "Nachos",
           "description": "Carne o pollo.",
+          "disambiguatingDescription": "Beef or chicken.",
+          "image": "assets/photos/antojitos-nachos.png",
           "offers": {
             "@type": "Offer",
             "price": "3500",
@@ -244,6 +284,8 @@
           "@type": "MenuItem",
           "name": "Chalupa",
           "description": "Carne o pollo.",
+          "disambiguatingDescription": "Beef or chicken.",
+          "image": "assets/photos/antojitos-chalupa.png",
           "offers": {
             "@type": "Offer",
             "price": "2000",
@@ -254,7 +296,9 @@
         {
           "@type": "MenuItem",
           "name": "Chicharrones",
+          "alternateName": "Crispy Pork Bites",
           "description": "Porción crujiente de la casa.",
+          "disambiguatingDescription": "House crispy pork portion.",
           "offers": {
             "@type": "Offer",
             "price": "4000",
@@ -265,7 +309,9 @@
         {
           "@type": "MenuItem",
           "name": "Hamburguesa Sencilla",
+          "alternateName": "Classic Burger",
           "description": "Acompañada con papas.",
+          "disambiguatingDescription": "Served with fries.",
           "offers": {
             "@type": "Offer",
             "price": "2500",
@@ -276,7 +322,10 @@
         {
           "@type": "MenuItem",
           "name": "Hamburguesa Gereni",
+          "alternateName": "Gereni Burger",
           "description": "Torta de huevo, tocineta, carne, cebolla caramelizada, jamón y queso.",
+          "disambiguatingDescription": "Egg patty, bacon, beef, caramelized onion, ham, and cheese.",
+          "image": "assets/photos/antojitos-hamburguesa-gereni.png",
           "offers": {
             "@type": "Offer",
             "price": "4200",
@@ -288,6 +337,7 @@
           "@type": "MenuItem",
           "name": "Patacones",
           "description": "Con frijoles molidos.",
+          "disambiguatingDescription": "With refried beans.",
           "offers": {
             "@type": "Offer",
             "price": "2260",
@@ -298,7 +348,9 @@
         {
           "@type": "MenuItem",
           "name": "Papas Fiesta",
+          "alternateName": "Fiesta Fries",
           "description": "Papas con topping especial de la casa.",
+          "disambiguatingDescription": "Fries with our house topping.",
           "offers": {
             "@type": "Offer",
             "price": "4100",
@@ -309,7 +361,9 @@
         {
           "@type": "MenuItem",
           "name": "Papas Fritas",
+          "alternateName": "French Fries",
           "description": "Orden individual de papas.",
+          "disambiguatingDescription": "Individual order of fries.",
           "offers": {
             "@type": "Offer",
             "price": "2500",
@@ -320,7 +374,9 @@
         {
           "@type": "MenuItem",
           "name": "Plato Surtido",
+          "alternateName": "Sampler Platter",
           "description": "Chicharrones, chorizo, pollo, salchichón, verdura y pico de gallo.",
+          "disambiguatingDescription": "Pork bites, chorizo, chicken, sausage, veggies, and pico de gallo.",
           "offers": {
             "@type": "Offer",
             "price": "8100",
@@ -331,7 +387,9 @@
         {
           "@type": "MenuItem",
           "name": "Brochetas de Camarón",
+          "alternateName": "Shrimp Skewers",
           "description": "Con patacones y pico de gallo.",
+          "disambiguatingDescription": "Served with patacones and pico de gallo.",
           "offers": {
             "@type": "Offer",
             "price": "4700",
@@ -342,7 +400,9 @@
         {
           "@type": "MenuItem",
           "name": "Alitas de Pollo (4 piezas)",
+          "alternateName": "Chicken Wings (4 pieces)",
           "description": "Salsa a elegir, acompañadas de papas.",
+          "disambiguatingDescription": "Your choice of sauce, served with fries.",
           "offers": {
             "@type": "Offer",
             "price": "5000",
@@ -353,7 +413,9 @@
         {
           "@type": "MenuItem",
           "name": "Alitas de Pollo (6 piezas)",
+          "alternateName": "Chicken Wings (6 pieces)",
           "description": "Salsa a elegir, acompañadas de papas.",
+          "disambiguatingDescription": "Your choice of sauce, served with fries.",
           "offers": {
             "@type": "Offer",
             "price": "7000",
@@ -364,7 +426,9 @@
         {
           "@type": "MenuItem",
           "name": "Alitas de Pollo (8 piezas)",
+          "alternateName": "Chicken Wings (8 pieces)",
           "description": "Salsa a elegir, acompañadas de papas.",
+          "disambiguatingDescription": "Your choice of sauce, served with fries.",
           "offers": {
             "@type": "Offer",
             "price": "9000",
@@ -372,7 +436,8 @@
             "availability": "https://schema.org/InStock"
           }
         }
-      ]
+      ],
+      "alternateName": "Cravings"
     },
     {
       "@type": "MenuSection",
@@ -381,7 +446,9 @@
         {
           "@type": "MenuItem",
           "name": "Costillas BBQ",
+          "alternateName": "BBQ Ribs",
           "description": "De cerdo en salsa BBQ con arroz y ensalada.",
+          "disambiguatingDescription": "Pork ribs in BBQ sauce with rice and salad.",
           "offers": {
             "@type": "Offer",
             "price": "5850",
@@ -392,7 +459,9 @@
         {
           "@type": "MenuItem",
           "name": "Filet de Pargo",
+          "alternateName": "Red Snapper Fillet",
           "description": "Preparado al gusto con papas y ensalada.",
+          "disambiguatingDescription": "Cooked to taste with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "5200",
@@ -403,7 +472,9 @@
         {
           "@type": "MenuItem",
           "name": "Filet de Tilapia",
+          "alternateName": "Tilapia Fillet",
           "description": "Al gusto, con papas y ensalada.",
+          "disambiguatingDescription": "Cooked to taste with fries and salad.",
           "offers": {
             "@type": "Offer",
             "price": "5085",
@@ -414,7 +485,9 @@
         {
           "@type": "MenuItem",
           "name": "Pollo Agridulce",
+          "alternateName": "Sweet and Sour Chicken",
           "description": "Trocitos de pollo en salsa agridulce con arroz y ensalada.",
+          "disambiguatingDescription": "Chicken bites in sweet and sour sauce with rice and salad.",
           "offers": {
             "@type": "Offer",
             "price": "5000",
@@ -425,7 +498,10 @@
         {
           "@type": "MenuItem",
           "name": "Filet de Pollo",
+          "alternateName": "Chicken Fillet",
           "description": "Al gusto, con papas y ensalada.",
+          "disambiguatingDescription": "Cooked to taste with fries and salad.",
+          "image": "assets/photos/especialidades-filet-de-pollo.png",
           "offers": {
             "@type": "Offer",
             "price": "5200",
@@ -436,7 +512,9 @@
         {
           "@type": "MenuItem",
           "name": "Pastas (Alfredo, Bechamel o Tomate)",
+          "alternateName": "Pasta (Alfredo, Béchamel or Tomato)",
           "description": "Servidas con pan de ajo.",
+          "disambiguatingDescription": "Served with garlic bread.",
           "offers": {
             "@type": "Offer",
             "price": "3500",
@@ -447,7 +525,9 @@
         {
           "@type": "MenuItem",
           "name": "Filete de Pollo en Salsa Bechamel",
+          "alternateName": "Chicken Fillet in Béchamel Sauce",
           "description": "Con arroz y ensalada.",
+          "disambiguatingDescription": "With rice and salad.",
           "offers": {
             "@type": "Offer",
             "price": "4520",
@@ -458,7 +538,9 @@
         {
           "@type": "MenuItem",
           "name": "Filet Miñon",
+          "alternateName": "Filet Mignon",
           "description": "Lomito recubierto con tocineta en salsa de vino.",
+          "disambiguatingDescription": "Tenderloin wrapped in bacon with wine sauce.",
           "offers": {
             "@type": "Offer",
             "price": "7150",
@@ -469,7 +551,9 @@
         {
           "@type": "MenuItem",
           "name": "Medallones de Lomito",
+          "alternateName": "Tenderloin Medallions",
           "description": "En salsa con papa asada y ensalada.",
+          "disambiguatingDescription": "In sauce with baked potato and salad.",
           "offers": {
             "@type": "Offer",
             "price": "7500",
@@ -481,6 +565,7 @@
           "@type": "MenuItem",
           "name": "Tomahawk / Ribeye / New York",
           "description": "Acompañado de papa asada y ensalada.",
+          "disambiguatingDescription": "Served with baked potato and salad.",
           "offers": {
             "@type": "Offer",
             "price": "13000",
@@ -491,7 +576,9 @@
         {
           "@type": "MenuItem",
           "name": "Lengua en Salsa",
+          "alternateName": "Beef Tongue in Sauce",
           "description": "Medallones en salsa de tomate con arroz y ensalada.",
+          "disambiguatingDescription": "Slices in tomato sauce with rice and salad.",
           "offers": {
             "@type": "Offer",
             "price": "5650",
@@ -502,7 +589,9 @@
         {
           "@type": "MenuItem",
           "name": "Gordon Bleu",
+          "alternateName": "Cordon Bleu",
           "description": "Pechuga de pollo con jamón, queso mozarela, puré y ensalada.",
+          "disambiguatingDescription": "Chicken breast with ham, mozzarella, mash, and salad.",
           "offers": {
             "@type": "Offer",
             "price": "5650",
@@ -510,7 +599,8 @@
             "availability": "https://schema.org/InStock"
           }
         }
-      ]
+      ],
+      "alternateName": "Specialties"
     },
     {
       "@type": "MenuSection",
@@ -520,6 +610,8 @@
           "@type": "MenuItem",
           "name": "Club Sandwich",
           "description": "Capas de pan, pollo y vegetales.",
+          "disambiguatingDescription": "Layers of bread, chicken, and vegetables.",
+          "image": "assets/photos/para-el-cafe-club-sandwich.png",
           "offers": {
             "@type": "Offer",
             "price": "4200",
@@ -531,6 +623,7 @@
           "@type": "MenuItem",
           "name": "Sandwich",
           "description": "Carne, pollo o jamón con queso.",
+          "disambiguatingDescription": "Beef, chicken, or ham with cheese.",
           "offers": {
             "@type": "Offer",
             "price": "2300",
@@ -541,7 +634,9 @@
         {
           "@type": "MenuItem",
           "name": "Tortilla de Queso",
+          "alternateName": "Cheese Tortilla",
           "description": "Con natilla.",
+          "disambiguatingDescription": "Served with sour cream.",
           "offers": {
             "@type": "Offer",
             "price": "2500",
@@ -552,7 +647,9 @@
         {
           "@type": "MenuItem",
           "name": "Tortilla con Torta de Huevo",
+          "alternateName": "Tortilla with Egg Patty",
           "description": "Preparada a la plancha.",
+          "disambiguatingDescription": "Griddled to order.",
           "offers": {
             "@type": "Offer",
             "price": "1200",
@@ -563,7 +660,9 @@
         {
           "@type": "MenuItem",
           "name": "Prensadas",
+          "alternateName": "Fried Cheese Tortillas",
           "description": "Tortillas fritas con queso.",
+          "disambiguatingDescription": "Fried tortillas with cheese.",
           "offers": {
             "@type": "Offer",
             "price": "1200",
@@ -575,6 +674,7 @@
           "@type": "MenuItem",
           "name": "Empanadas",
           "description": "Rellenas al gusto.",
+          "disambiguatingDescription": "Filled to your liking.",
           "offers": {
             "@type": "Offer",
             "price": "1800",
@@ -585,7 +685,9 @@
         {
           "@type": "MenuItem",
           "name": "Arepas con Natilla o Mermelada",
+          "alternateName": "Arepas with Cream or Jam",
           "description": "Dulce casero para acompañar el café.",
+          "disambiguatingDescription": "Homemade sweet treat for your coffee.",
           "offers": {
             "@type": "Offer",
             "price": "1700",
@@ -593,7 +695,8 @@
             "availability": "https://schema.org/InStock"
           }
         }
-      ]
+      ],
+      "alternateName": "Coffee Time"
     },
     {
       "@type": "MenuSection",
@@ -602,7 +705,10 @@
         {
           "@type": "MenuItem",
           "name": "Café",
+          "alternateName": "Coffee",
           "description": "Taza de café chorreado.",
+          "disambiguatingDescription": "Pour-over coffee cup.",
+          "image": "assets/photos/bebidas-cafe.png",
           "offers": {
             "@type": "Offer",
             "price": "1200",
@@ -614,6 +720,7 @@
           "@type": "MenuItem",
           "name": "Agua Dulce",
           "description": "Bebida tradicional de tapa de dulce.",
+          "disambiguatingDescription": "Traditional sugarcane drink.",
           "offers": {
             "@type": "Offer",
             "price": "900",
@@ -624,7 +731,9 @@
         {
           "@type": "MenuItem",
           "name": "Chocolate",
+          "alternateName": "Hot Chocolate",
           "description": "Chocolate caliente.",
+          "disambiguatingDescription": "Hot chocolate.",
           "offers": {
             "@type": "Offer",
             "price": "1200",
@@ -635,7 +744,9 @@
         {
           "@type": "MenuItem",
           "name": "Té Negro",
+          "alternateName": "Black Tea",
           "description": "Infusión caliente.",
+          "disambiguatingDescription": "Hot infusion.",
           "offers": {
             "@type": "Offer",
             "price": "800",
@@ -646,7 +757,9 @@
         {
           "@type": "MenuItem",
           "name": "Batidos en Leche",
+          "alternateName": "Milk Shakes",
           "description": "Sabores a elección.",
+          "disambiguatingDescription": "Choice of flavors.",
           "offers": {
             "@type": "Offer",
             "price": "2300",
@@ -657,7 +770,9 @@
         {
           "@type": "MenuItem",
           "name": "Frescos Naturales",
+          "alternateName": "Fresh Juices",
           "description": "Jugos naturales del día.",
+          "disambiguatingDescription": "Daily natural juices.",
           "offers": {
             "@type": "Offer",
             "price": "2000",
@@ -665,9 +780,11 @@
             "availability": "https://schema.org/InStock"
           }
         }
-      ]
+      ],
+      "alternateName": "Drinks"
     }
-  ]
+  ],
+  "dateModified": "2025-10-12T18:03:13.505Z"
 }
 </script>
 </head>
@@ -743,7 +860,7 @@
 <main class="menu-main">
 <div class="menu-columns" id="menu-container">
   <!-- Static fallback markup; hydrated by scripts/loadMenu.js when JS is available -->
-                                <!-- FALLBACK_MENU_START -->
+                                                                                                                                <!-- FALLBACK_MENU_START -->
   <div class="menu-column menu-column--left">
     <section class="menu-section">
       <h2 class="menu-section__title">
@@ -1451,7 +1568,7 @@
       </article>
     </section>
   </div>
-                <!-- FALLBACK_MENU_END -->
+                                                                <!-- FALLBACK_MENU_END -->
 </div>
 </main>
 <footer class="menu-footer">

--- a/tools/check-menu-render.js
+++ b/tools/check-menu-render.js
@@ -44,12 +44,29 @@ async function main() {
 
   const sections = [...dom.window.document.querySelectorAll('main section')];
   const footerNote = dom.window.document.querySelector('#menu-updated')?.textContent.trim();
+  const schemaElement = dom.window.document.getElementById('menu-schema');
+  let schemaSummary = 'No disponible';
+
+  if (schemaElement) {
+    try {
+      const schema = JSON.parse(schemaElement.textContent || 'null');
+      if (schema && typeof schema === 'object') {
+        const count = Array.isArray(schema.hasMenuSection) ? schema.hasMenuSection.length : 0;
+        schemaSummary = `${count} secciones`; 
+      } else {
+        schemaSummary = 'No válido';
+      }
+    } catch (error) {
+      schemaSummary = `Error: ${error.message}`;
+    }
+  }
 
   console.log(`Secciones renderizadas: ${sections.length}`);
   console.log(
     sections.map(section => `- ${section.querySelector('h2')?.textContent || 'Sin título'} (${section.querySelectorAll('.dish').length} platillos)`).join('\n')
   );
   console.log(`Nota de actualización: ${footerNote || 'No visible'}`);
+  console.log(`Schema JSON-LD: ${schemaSummary}`);
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- generate up-to-date menu JSON-LD when building the static fallback so the schema mirrors menu data
- update the client loader to refresh the structured data script and include bilingual fields and offers
- extend the menu render check to report the schema sections count

## Testing
- npm run check:all

------
https://chatgpt.com/codex/tasks/task_e_68faac16deb883239d1e4613663ec3d1