### PR TITLE
Implement automation scripts for menu agents

### DIFF
--- a/ai/scripts/analytics.mjs
+++ b/ai/scripts/analytics.mjs
@@ -1,3 +1,109 @@
 // ai/scripts/analytics.mjs
-console.log('[analytics] placeholder: collect basic metrics and write ai/logs/analytics.jsonl');
-process.exit(0);
+import { existsSync, mkdirSync, appendFileSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const MENU_JSON = path.join(ROOT, 'data', 'menu.json');
+const LOG_DIR = path.join(ROOT, 'ai', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'menu-analytics.jsonl');
+
+function parsePrice(value) {
+  if (typeof value !== 'string') return null;
+  const numeric = value.replace(/[^\d]/g, '');
+  if (!numeric) return null;
+  return Number.parseInt(numeric, 10);
+}
+
+function collectMetrics() {
+  if (!existsSync(MENU_JSON)) {
+    return {
+      sections: 0,
+      items: 0,
+      price_min: null,
+      price_max: null,
+      price_avg: null,
+      updated_at: null
+    };
+  }
+
+  const data = JSON.parse(readFileSync(MENU_JSON, 'utf8'));
+  const sections = Array.isArray(data.sections) ? data.sections : [];
+  let items = 0;
+  const prices = [];
+
+  sections.forEach(section => {
+    if (!section || !Array.isArray(section.items)) return;
+    section.items.forEach(item => {
+      items += 1;
+      const price = parsePrice(item?.price);
+      if (Number.isFinite(price)) {
+        prices.push(price);
+      }
+    });
+  });
+
+  prices.sort((a, b) => a - b);
+  const priceMin = prices.length > 0 ? prices[0] : null;
+  const priceMax = prices.length > 0 ? prices[prices.length - 1] : null;
+  const priceAvg = prices.length > 0 ? Math.round(prices.reduce((sum, value) => sum + value, 0) / prices.length) : null;
+
+  return {
+    sections: sections.length,
+    items,
+    price_min: priceMin,
+    price_max: priceMax,
+    price_avg: priceAvg,
+    updated_at: data.updatedAt || null
+  };
+}
+
+function appendLog(entry) {
+  if (!existsSync(LOG_DIR)) {
+    mkdirSync(LOG_DIR, { recursive: true });
+  }
+  appendFileSync(LOG_FILE, JSON.stringify(entry) + '\n', 'utf8');
+}
+
+function main() {
+  const startedAt = Date.now();
+  let status = 'ok';
+  let metrics;
+  let errorMessage = null;
+
+  try {
+    metrics = collectMetrics();
+  } catch (error) {
+    status = 'error';
+    errorMessage = error.message;
+    metrics = {
+      sections: 0,
+      items: 0,
+      price_min: null,
+      price_max: null,
+      price_avg: null,
+      updated_at: null
+    };
+  }
+
+  const logEntry = {
+    ts: new Date().toISOString(),
+    ai_generated: true,
+    agent: 'menu-analytics',
+    status,
+    duration_ms: Date.now() - startedAt,
+    metrics,
+    error: errorMessage
+  };
+
+  appendLog(logEntry);
+
+  if (status === 'ok') {
+    console.log('[analytics] Métricas registradas:', JSON.stringify(metrics));
+    process.exit(0);
+  } else {
+    console.error('[analytics] Error al recopilar métricas:', errorMessage);
+    process.exit(1);
+  }
+}
+
+main();

--- a/ai/scripts/data-sync.mjs
+++ b/ai/scripts/data-sync.mjs
@@ -1,3 +1,90 @@
 // ai/scripts/data-sync.mjs
-console.log('[data] placeholder: normalize data/ sources and emit caches. Exit 0.');
-process.exit(0);
+import { execFile } from 'node:child_process';
+import { existsSync, appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const LOG_DIR = path.join(ROOT, 'ai', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'menu-data.jsonl');
+const MENU_JSON = path.join(ROOT, 'data', 'menu.json');
+
+function runSyncMenu() {
+  return new Promise((resolve, reject) => {
+    const child = execFile('node', ['tools/sync-menu.js'], { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`sync-menu.js exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function readMenuStats() {
+  if (!existsSync(MENU_JSON)) {
+    return { sections: 0, items: 0, updatedAt: null };
+  }
+  const raw = readFileSync(MENU_JSON, 'utf8');
+  const data = JSON.parse(raw);
+  const sections = Array.isArray(data.sections) ? data.sections : [];
+  let itemCount = 0;
+  sections.forEach(section => {
+    if (section && Array.isArray(section.items)) {
+      itemCount += section.items.length;
+    }
+  });
+  return {
+    sections: sections.length,
+    items: itemCount,
+    updatedAt: data.updatedAt || null
+  };
+}
+
+function appendLog(entry) {
+  if (!existsSync(LOG_DIR)) {
+    mkdirSync(LOG_DIR, { recursive: true });
+  }
+  appendFileSync(LOG_FILE, JSON.stringify(entry) + '\n', 'utf8');
+}
+
+async function main() {
+  const startedAt = Date.now();
+  let status = 'ok';
+  let errorMessage = null;
+
+  try {
+    await runSyncMenu();
+  } catch (error) {
+    status = 'error';
+    errorMessage = error.message;
+  }
+
+  const durationMs = Date.now() - startedAt;
+  const stats = readMenuStats();
+
+  const logEntry = {
+    ts: new Date().toISOString(),
+    ai_generated: true,
+    agent: 'menu-data',
+    status,
+    duration_ms: durationMs,
+    sections: stats.sections,
+    items: stats.items,
+    updated_at: stats.updatedAt,
+    error: errorMessage
+  };
+
+  appendLog(logEntry);
+
+  if (status === 'ok') {
+    console.log('[data] menu.json actualizado:', JSON.stringify(stats));
+    process.exit(0);
+  } else {
+    console.error('[data] fallo al sincronizar el menú:', errorMessage);
+    process.exit(1);
+  }
+}
+
+main();

--- a/ai/scripts/image-optimize.mjs
+++ b/ai/scripts/image-optimize.mjs
@@ -1,3 +1,216 @@
 // ai/scripts/image-optimize.mjs
-console.log('[image] placeholder: add your image pipeline here (sharp/squoosh). Exit 0.');
-process.exit(0);
+import { readdir, stat, mkdir, writeFile, copyFile } from 'node:fs/promises';
+import { createWriteStream, existsSync } from 'node:fs';
+import path from 'node:path';
+
+const SOURCE_DIR = path.join(process.cwd(), 'assets', 'photos');
+const OUTPUT_DIR = path.join(SOURCE_DIR, 'optimized');
+const TARGET_WIDTHS = [640, 1280];
+const QUALITY = 80;
+const LOG_PATH = path.join(process.cwd(), 'ai', 'logs', 'menu-image.jsonl');
+
+async function ensureDir(dir) {
+  await mkdir(dir, { recursive: true });
+}
+
+function isProcessableFile(file) {
+  const allowed = ['.png', '.jpg', '.jpeg'];
+  return allowed.includes(path.extname(file).toLowerCase());
+}
+
+async function gatherSourceFiles() {
+  const entries = await readdir(SOURCE_DIR, { withFileTypes: true });
+  return entries
+    .filter(entry => entry.isFile() && isProcessableFile(entry.name))
+    .map(entry => path.join(SOURCE_DIR, entry.name));
+}
+
+function outputName(base, suffix, extension = 'webp') {
+  const extless = base.replace(/\.[^.]+$/, '');
+  return `${extless}-${suffix}.${extension}`;
+}
+
+async function needsRegeneration(srcPath, destPath) {
+  try {
+    const [srcStat, destStat] = await Promise.all([stat(srcPath), stat(destPath)]);
+    return destStat.mtimeMs < srcStat.mtimeMs;
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return true;
+    }
+    throw err;
+  }
+}
+
+async function writeManifest(manifest) {
+  const manifestPath = path.join(OUTPUT_DIR, 'manifest.json');
+  const payload = {
+    ai_generated: true,
+    generated_at: new Date().toISOString(),
+    items: manifest
+  };
+  await writeFile(manifestPath, JSON.stringify(payload, null, 2));
+}
+
+async function appendLog(entry) {
+  const logDir = path.dirname(LOG_PATH);
+  if (!existsSync(logDir)) {
+    await mkdir(logDir, { recursive: true });
+  }
+  await writeFile(LOG_PATH, JSON.stringify(entry) + '\n', { flag: 'a' });
+}
+
+let cachedSharp = undefined;
+async function loadSharp() {
+  if (cachedSharp !== undefined) {
+    return cachedSharp;
+  }
+  try {
+    const mod = await import('sharp');
+    cachedSharp = mod.default || mod;
+    return cachedSharp;
+  } catch (error) {
+    console.warn('[image] sharp no está disponible; se realizará copia sin conversión.');
+    cachedSharp = null;
+    return cachedSharp;
+  }
+}
+
+async function processWithSharp(sharp, filePath, fileName) {
+  const results = [];
+  const metadata = await sharp(filePath).metadata();
+  const naturalWidth = metadata.width || null;
+
+  for (const width of TARGET_WIDTHS) {
+    if (naturalWidth && width > naturalWidth) {
+      continue;
+    }
+    const targetName = outputName(fileName, `${width}w`);
+    const destPath = path.join(OUTPUT_DIR, targetName);
+    const regenerate = await needsRegeneration(filePath, destPath);
+    if (!regenerate) {
+      results.push({
+        source: fileName,
+        output: targetName,
+        width,
+        reused: true
+      });
+      continue;
+    }
+
+    await new Promise((resolve, reject) => {
+      const transformer = sharp(filePath)
+        .resize({ width, withoutEnlargement: true })
+        .webp({ quality: QUALITY, effort: 6 });
+      const outStream = createWriteStream(destPath);
+      outStream.on('finish', resolve);
+      outStream.on('error', reject);
+      transformer.on('error', reject);
+      transformer.pipe(outStream);
+    });
+
+    const { size } = await stat(destPath);
+    results.push({
+      source: fileName,
+      output: targetName,
+      width,
+      reused: false,
+      bytes: size
+    });
+  }
+
+  if (results.length === 0) {
+    const fallbackName = outputName(fileName, 'original', path.extname(fileName).slice(1));
+    const destPath = path.join(OUTPUT_DIR, fallbackName);
+    await copyFile(filePath, destPath);
+    const { size } = await stat(destPath);
+    results.push({
+      source: fileName,
+      output: fallbackName,
+      width: naturalWidth,
+      reused: false,
+      bytes: size,
+      note: 'copied-original'
+    });
+  }
+
+  return results;
+}
+
+async function processWithoutSharp(filePath, fileName) {
+  const targetName = outputName(fileName, 'original', path.extname(fileName).slice(1));
+  const destPath = path.join(OUTPUT_DIR, targetName);
+  const regenerate = await needsRegeneration(filePath, destPath);
+  if (regenerate) {
+    await copyFile(filePath, destPath);
+  }
+  const { size } = await stat(destPath);
+  return [{
+    source: fileName,
+    output: targetName,
+    width: null,
+    reused: !regenerate,
+    bytes: size,
+    note: 'copied-original'
+  }];
+}
+
+async function processImage(filePath) {
+  const fileName = path.basename(filePath);
+  const sharp = await loadSharp();
+  if (sharp) {
+    return processWithSharp(sharp, filePath, fileName);
+  }
+  return processWithoutSharp(filePath, fileName);
+}
+
+async function main() {
+  const start = Date.now();
+  await ensureDir(OUTPUT_DIR);
+
+  const files = await gatherSourceFiles();
+  if (files.length === 0) {
+    console.warn('[image] No se encontraron imágenes en assets/photos');
+  }
+
+  const manifest = [];
+  let optimizedCount = 0;
+
+  for (const file of files) {
+    const outputs = await processImage(file);
+    manifest.push({
+      source: path.basename(file),
+      variants: outputs
+    });
+    optimizedCount += outputs.filter(entry => !entry.reused).length;
+  }
+
+  await writeManifest(manifest);
+
+  const logEntry = {
+    ts: new Date().toISOString(),
+    ai_generated: true,
+    agent: 'menu-image',
+    status: 'ok',
+    duration_ms: Date.now() - start,
+    sources: files.length,
+    optimized: optimizedCount
+  };
+
+  await appendLog(logEntry);
+  console.log(`[image] Variantes procesadas: ${optimizedCount} (${files.length} archivos origen).`);
+}
+
+main().catch(async error => {
+  const logEntry = {
+    ts: new Date().toISOString(),
+    ai_generated: true,
+    agent: 'menu-image',
+    status: 'error',
+    duration_ms: 0,
+    error: error.message
+  };
+  await appendLog(logEntry).catch(() => {});
+  console.error('[image] Error durante la optimización:', error);
+  process.exit(1);
+});

--- a/ai/scripts/package-render.mjs
+++ b/ai/scripts/package-render.mjs
@@ -1,3 +1,84 @@
 // ai/scripts/package-render.mjs
-console.log('[packaging] placeholder: render labels or PDFs. Exit 0.');
-process.exit(0);
+import { execFile } from 'node:child_process';
+import { existsSync, mkdirSync, appendFileSync, statSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const OUTPUT_DIR = path.join(ROOT, 'output');
+const LOG_DIR = path.join(ROOT, 'ai', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'menu-packaging.jsonl');
+
+function runExportMenu() {
+  return new Promise((resolve, reject) => {
+    const child = execFile('node', ['tools/export-menu.js'], { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`export-menu.js exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function collectArtifacts() {
+  if (!existsSync(OUTPUT_DIR)) {
+    return [];
+  }
+  const entries = readdirSync(OUTPUT_DIR)
+    .filter(name => name.toLowerCase().endsWith('.pdf'))
+    .map(name => {
+      const fullPath = path.join(OUTPUT_DIR, name);
+      const stats = statSync(fullPath);
+      return {
+        file: name,
+        bytes: stats.size,
+        mtime: stats.mtime.toISOString()
+      };
+    });
+  return entries.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+function appendLog(entry) {
+  if (!existsSync(LOG_DIR)) {
+    mkdirSync(LOG_DIR, { recursive: true });
+  }
+  appendFileSync(LOG_FILE, JSON.stringify(entry) + '\n', 'utf8');
+}
+
+async function main() {
+  const start = Date.now();
+  let status = 'ok';
+  let errorMessage = null;
+
+  try {
+    await runExportMenu();
+  } catch (error) {
+    status = 'error';
+    errorMessage = error.message;
+  }
+
+  const artifacts = collectArtifacts();
+  const logEntry = {
+    ts: new Date().toISOString(),
+    ai_generated: true,
+    agent: 'menu-packaging',
+    status,
+    duration_ms: Date.now() - start,
+    artifacts,
+    error: errorMessage
+  };
+
+  appendLog(logEntry);
+
+  if (status === 'ok') {
+    console.log(`[packaging] Export completado. ${artifacts.length} PDFs listados.`);
+    process.exit(0);
+  } else {
+    console.error('[packaging] Error al exportar el menú:', errorMessage);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- implement the menu data agent to run the Markdown→JSON sync and append structured logs
- add an image optimization pipeline that writes variant manifests and degrades gracefully when sharp is unavailable
- wire the packaging and analytics agents to produce PDFs, collect metrics, and emit JSONL logs

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_68faae90db48832383f75ebc9ec79457