### PR TITLE
Fix menu artifact workflow to rebase before pushing

### DIFF
--- a/.github/workflows/update-menu-artifacts.yml
+++ b/.github/workflows/update-menu-artifacts.yml
@@ -63,4 +63,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add menu.html data/menu.json output/Menu_Gereni_digital.pdf output/Menu_Gereni_digital_*.pdf output/Menu_Gereni_print.pdf
           git commit -m "chore: auto-update menu artifacts [skip ci]"
-          git push
+          git pull --rebase origin main
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary
- ensure the menu artifact workflow rebases onto the latest main branch before pushing
- push explicitly to main after rebasing to avoid fast-forward failures

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fab1b1f5b08323900b4af8efe49108