### PR TITLE
feat: add offline caching for menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2025-10-24
+- Improve service worker caching to support offline access to the menu shell and data.
+
 ## 2025-10-23
 - Initial changelog
 

--- a/menu.html
+++ b/menu.html
@@ -860,7 +860,7 @@
 <main class="menu-main">
 <div class="menu-columns" id="menu-container">
   <!-- Static fallback markup; hydrated by scripts/loadMenu.js when JS is available -->
-                                                                                                                                <!-- FALLBACK_MENU_START -->
+                                                                                                                                                                                                                                                                <!-- FALLBACK_MENU_START -->
   <div class="menu-column menu-column--left">
     <section class="menu-section">
       <h2 class="menu-section__title">
@@ -1568,7 +1568,7 @@
       </article>
     </section>
   </div>
-                                                                <!-- FALLBACK_MENU_END -->
+                                                                                                                                <!-- FALLBACK_MENU_END -->
 </div>
 </main>
 <footer class="menu-footer">

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,23 +1,65 @@
-self.addEventListener('install', () => {
+const SHELL_CACHE = 'gereni-shell-v1';
+const DATA_CACHE = 'gereni-data-v1';
+const FB_CACHE = 'gereni-fb-cache-v1';
+
+const PRECACHE_URLS = [
+  'index.html',
+  'menu.html',
+  'styles/main.css',
+  'styles/print.css',
+  'scripts/i18n.js',
+  'scripts/theme.js',
+  'scripts/headerControls.js',
+  'scripts/loadMenu.js',
+  'scripts/pdfLink.js',
+  'scripts/swRegister.js',
+  'data/menu.json',
+  'assets/logo-gereni-bar-restaurant.png',
+  'assets/photos/cocktails-600x441.png',
+  'assets/photos/Flag_of_Costa_Rica.svg',
+  'assets/qr/gereni-menu-qr.png',
+  'assets/El_Rancho.jpg',
+  'favicon.svg'
+];
+
+const DATA_PRECACHE_URLS = ['data/menu.json'];
+
+const resolveUrl = (path) => new URL(path, self.location).toString();
+
+const isSameOrigin = (request) => new URL(request.url).origin === self.location.origin;
+
+self.addEventListener('install', (event) => {
   // Activate the service worker immediately so caching works on first load.
   self.skipWaiting();
-});
-
-self.addEventListener('activate', event => {
-  // Remove old caches that do not match the current version.
-  const currentCaches = ['gereni-fb-cache-v1'];
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys
-          .filter(key => key.startsWith('gereni-') && !currentCaches.includes(key))
-          .map(key => caches.delete(key))
-      )
-    ).then(() => self.clients.claim())
+    (async () => {
+      const shellCache = await caches.open(SHELL_CACHE);
+      await shellCache.addAll(PRECACHE_URLS.map(resolveUrl));
+
+      const dataCache = await caches.open(DATA_CACHE);
+      await dataCache.addAll(DATA_PRECACHE_URLS.map(resolveUrl));
+    })()
   );
 });
 
-const isFacebookEmbedRequest = request => {
+self.addEventListener('activate', (event) => {
+  // Remove old caches that do not match the current version.
+  const currentCaches = [SHELL_CACHE, DATA_CACHE, FB_CACHE];
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith('gereni-') && !currentCaches.includes(key))
+            .map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+const isFacebookEmbedRequest = (request) => {
   if (request.method !== 'GET') {
     return false;
   }
@@ -37,38 +79,121 @@ const isFacebookEmbedRequest = request => {
   return false;
 };
 
-self.addEventListener('fetch', event => {
-  if (!isFacebookEmbedRequest(event.request)) {
+const cacheFirst = async (request) => {
+  const cache = await caches.open(SHELL_CACHE);
+  const cached = await cache.match(request);
+  if (cached) {
+    return cached;
+  }
+
+  const response = await fetch(request);
+  if (response && response.ok) {
+    cache.put(request, response.clone());
+  }
+  return response;
+};
+
+const networkFirstData = async (request) => {
+  const cache = await caches.open(DATA_CACHE);
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) {
+      return cached;
+    }
+    throw error;
+  }
+};
+
+const handleNavigation = async (request) => {
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      const cache = await caches.open(SHELL_CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cache = await caches.open(SHELL_CACHE);
+    const url = new URL(request.url);
+    const fallbackPaths = [];
+    if (url.pathname.endsWith('/menu.html')) {
+      fallbackPaths.push('menu.html');
+    }
+    fallbackPaths.push('index.html');
+
+    for (const path of fallbackPaths) {
+      const cached = await cache.match(resolveUrl(path));
+      if (cached) {
+        return cached;
+      }
+    }
+    throw error;
+  }
+};
+
+const handleFacebookRequest = async (request, event) => {
+  const cache = await caches.open(FB_CACHE);
+  const cached = await cache.match(request);
+
+  const networkFetch = fetch(request)
+    .then((response) => {
+      if (response && (response.ok || response.type === 'opaque')) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch((error) => {
+      if (cached) {
+        return cached;
+      }
+      throw error;
+    });
+
+  if (cached) {
+    event.waitUntil(networkFetch.catch(() => undefined));
+    return cached;
+  }
+
+  return networkFetch;
+};
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
     return;
   }
 
-  event.respondWith(
-    (async () => {
-      const cacheName = 'gereni-fb-cache-v1';
-      const cache = await caches.open(cacheName);
-      const cached = await cache.match(event.request);
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return;
+  }
 
-      const networkFetch = fetch(event.request)
-        .then(response => {
-          if (response && (response.ok || response.type === 'opaque')) {
-            cache.put(event.request, response.clone());
-          }
-          return response;
-        })
-        .catch(error => {
-          if (cached) {
-            return cached;
-          }
-          throw error;
-        });
+  if (isFacebookEmbedRequest(request)) {
+    event.respondWith(handleFacebookRequest(request, event));
+    return;
+  }
 
-      if (cached) {
-        // Return cached response immediately and refresh in the background.
-        event.waitUntil(networkFetch.catch(() => undefined));
-        return cached;
-      }
+  if (!isSameOrigin(request)) {
+    return;
+  }
 
-      return networkFetch;
-    })()
-  );
+  const url = new URL(request.url);
+
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigation(request));
+    return;
+  }
+
+  if (url.pathname.endsWith('/data/menu.json')) {
+    event.respondWith(networkFirstData(request));
+    return;
+  }
+
+  event.respondWith(cacheFirst(request));
 });


### PR DESCRIPTION
## Summary
- add precaching and offline handling in the service worker so the menu shell and data are available offline
- regenerate the static fallback section in `menu.html` after running the build script
- record the offline caching upgrade in the changelog

## Testing
- npm run check:all

------
https://chatgpt.com/codex/tasks/task_e_68faba462b3483238b819cef05a42301