### PR TITLE
Add seeded backlog for menu workflow

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,20 @@
+# Backlog
+
+## To Do
+- [ ] Contenido — Actualizar `content/menu.md` con los cambios aprobados manteniendo el formato de precios y revisando ortografía antes de liberar nueva versión.
+- [ ] Soporte técnico — Ejecutar `node tools/sync-menu.js` después de cada edición de contenido para mantener `data/menu.json` sincronizado con la fuente.
+- [ ] Soporte técnico — Correr `npm run check:all` y documentar cualquier incidente previo a la publicación.
+- [ ] Diseño/Maquetación — Sincronizar la plantilla de Canva con el texto actualizado respetando tipografías, columnas y paleta definidos en la guía.
+- [ ] Diseño/Maquetación — Verificar que el bloque del QR mantenga dimensiones de 60 × 60 mm, texto acompañante y enlace vigente.
+- [ ] Soporte técnico — Exportar `Menu_Gereni_print.pdf` y las variantes digitales con `npm run export:menu`, guardarlas en `output/` y confirmar nombres de archivo.
+- [ ] Soporte técnico — Actualizar `design/canva/licenses/README.md` cuando se incorporen nuevos recursos o licencias.
+- [ ] Contenido — Revisar `workflow/reminders.md` al cierre de cada sesión y anotar seguimientos pendientes.
+- [ ] Soporte técnico — Confirmar que el dueño tenga acceso al enlace editable de Canva y credenciales necesarias según `handoff.md`.
+
+## In Progress
+- [ ] Diseño/Maquetación — Recolectar información de licencia y evidencias para el logo principal y texturas listadas como “pendiente” en `design/canva/licenses/`.
+- [ ] Soporte técnico — Coordinar la actualización del QR de alimentos y bebidas siguiendo `tools/qr/README.md` y validar su funcionamiento en dispositivos móviles.
+
+## Done
+- [x] Soporte técnico — Documentó el flujo de actualización completo en `workflow.md`, incluyendo pasos, checklist y roles.
+- [x] Soporte técnico — Preparó la guía de traspaso `handoff.md` para que el dueño pueda actualizar el menú de forma independiente.


### PR DESCRIPTION
## Summary
- add a repository backlog with to do, in progress, and done sections
- seed actionable tasks derived from workflow, design guide, and handoff documentation
- assign responsible roles so the team can track ownership

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fbf909fe448323a70d90014b874cc9