### PR TITLE
Update Canva template link metadata

### DIFF
--- a/design/canva/template-link.md
+++ b/design/canva/template-link.md
@@ -2,8 +2,8 @@
 
 Guarda aquí el vínculo para editar o duplicar la plantilla oficial del menú.
 
-- Última actualización: (pendiente)
-- URL compartida: (agrega aquí el enlace público de Canva)
+- Última actualización: 2025-10-24
+- URL compartida: *(pendiente de actualizar; se requiere acceso a Canva para obtener el enlace de edición)*
 
 ## Cómo obtener el enlace correcto
 1. Abre la plantilla en Canva (asegúrate de tener permisos de edición).
@@ -12,5 +12,10 @@ Guarda aquí el vínculo para editar o duplicar la plantilla oficial del menú.
 4. Copia el enlace de la opción **Enlace para editar**.
 5. Pega el enlace en la línea “URL compartida” de este archivo.
 6. Notifica a Codex si cambias los permisos o duplicas la plantilla.
+
+## Notas sobre permisos y acceso
+- Actualmente no se pudo verificar el enlace porque el agente no cuenta con acceso directo a Canva desde este entorno.
+- Si en el futuro se limita el acceso del enlace a usuarios específicos, documenta la fecha del cambio, el motivo y el equipo contactado para reactivar el acceso abierto.
+- Cuando se deshabilite la opción **Puede editar**, agrega instrucciones alternativas (por ejemplo, solicitud de acceso o duplicación manual) y actualiza la fecha en este archivo.
 
 > Importante: evita compartir enlaces restringidos a correos individuales, ya que el flujo depende de un enlace estable para colaboraciones futuras.


### PR DESCRIPTION
## Summary
- update the Canva template link tracker with the current refresh date
- record that the shared edit URL is still pending because Canva access is unavailable in this environment
- add guidance for documenting future permission changes to the Canva share link

## Testing
- not run (markdown-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fbf913605c8323bafe85518e395e00