### PR TITLE
Add Instagram button to home panel

### DIFF
--- a/assets/icons/instagram.svg
+++ b/assets/icons/instagram.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <title>Instagram</title>
+  <path fill="currentColor" d="M7 3h10a4 4 0 0 1 4 4v10a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4V7a4 4 0 0 1 4-4Zm0 2a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H7Zm5 3a5 5 0 1 1 0 10 5 5 0 0 1 0-10Zm0 2.25A2.75 2.75 0 1 0 12 16.75 2.75 2.75 0 0 0 12 10.25Zm5.25-3.5a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0Z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -115,11 +115,17 @@
       Descargar Menú en PDF
      </a>
 </div>
-<div class="facebook-button">
-<a class="facebook-link" data-i18n-en="Open Facebook" data-i18n-es="Abrir Facebook" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
-      Abrir Facebook
-     </a>
-</div>
+ <div class="facebook-button">
+  <a class="facebook-link" data-i18n-en="Open Facebook" data-i18n-es="Abrir Facebook" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
+   Abrir Facebook
+  </a>
+ </div>
+ <div class="instagram-button">
+  <a class="instagram-link" data-i18n-en="Open Instagram" data-i18n-es="Abrir Instagram" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank">
+   <img alt="" aria-hidden="true" class="instagram-icon" src="assets/icons/instagram.svg" />
+   Abrir Instagram
+  </a>
+ </div>
 </div>
 </main>
 <footer>

--- a/styles/main.css
+++ b/styles/main.css
@@ -312,7 +312,8 @@ body.inicio header::after {
   flex-wrap:wrap;
 }
 
-.facebook-button {
+.facebook-button,
+.instagram-button {
   display:flex;
   justify-content:center;
 }
@@ -524,7 +525,8 @@ footer {
   margin:0 auto;
 }
 
-.facebook-link {
+.facebook-link,
+.instagram-link {
   align-self:center;
   background-color:var(--gereni-green);
   color:#fff;
@@ -534,13 +536,25 @@ footer {
   font-weight:600;
   letter-spacing:0.03em;
   transition:background-color 0.2s ease, transform 0.2s ease;
+  display:inline-flex;
+  align-items:center;
+  gap:0.55rem;
 }
 
 .facebook-link:hover,
-.facebook-link:focus-visible {
+.facebook-link:focus-visible,
+.instagram-link:hover,
+.instagram-link:focus-visible {
   background-color:var(--gereni-brown);
   color:#fff;
   transform:translateY(-1px);
+}
+
+.instagram-icon {
+  width:1.1rem;
+  height:1.1rem;
+  flex-shrink:0;
+  display:block;
 }
 
 .social-section h2 {
@@ -716,7 +730,8 @@ body[data-theme="dark"].inicio section {
   box-shadow:var(--card-shadow);
 }
 
-body[data-theme="dark"].inicio .facebook-link {
+body[data-theme="dark"].inicio .facebook-link,
+body[data-theme="dark"].inicio .instagram-link {
   background-color:var(--gereni-brown);
   color:#0f110d;
 }


### PR DESCRIPTION
## Summary
- add an Instagram call-to-action below the Facebook link on the home panel with localized labels
- style the new Instagram button alongside the existing Facebook button, including hover/focus and dark theme states
- add an Instagram SVG icon asset for use within the button

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_68fc618aa95c8323a42461f12971da37