### PR TITLE
Add dynamic home highlights card to hero

### DIFF
--- a/data/home-highlights.json
+++ b/data/home-highlights.json
@@ -1,0 +1,61 @@
+{
+  "ai-generated": true,
+  "specialMenus": [
+    {
+      "title": {
+        "es": "Parrillada del bosque",
+        "en": "Forest grill platter"
+      },
+      "description": {
+        "es": "Selección para compartir con chorizo artesanal, pollo ahumado y vegetales asados con romero de la finca.",
+        "en": "Shareable spread with house-made chorizo, smoked chicken, and farm rosemary grilled vegetables."
+      },
+      "price": "₡18 500",
+      "ctaLabel": {
+        "es": "Reservar mesa",
+        "en": "Reserve a table"
+      },
+      "url": "https://wa.me/50685351817"
+    },
+    {
+      "title": {
+        "es": "Cóctel de temporada",
+        "en": "Seasonal cocktail"
+      },
+      "description": {
+        "es": "Guayaba fresca, ron dorado y sirope de jengibre servido frappé para tardes tropicales.",
+        "en": "Fresh guava, golden rum, and ginger syrup served frozen for tropical afternoons."
+      },
+      "price": "₡4 800",
+      "url": "https://www.facebook.com/baryrestaurantegereni"
+    }
+  ],
+  "socialUpdates": [
+    {
+      "title": {
+        "es": "Música en vivo viernes",
+        "en": "Live music Friday"
+      },
+      "description": {
+        "es": "Acompáñanos este viernes a las 7 p.m. con boleros acústicos y cocteles 2x1 hasta las 9 p.m.",
+        "en": "Join us Friday at 7 p.m. for acoustic boleros and 2-for-1 cocktails until 9 p.m."
+      },
+      "ctaLabel": {
+        "es": "Confirmar asistencia",
+        "en": "RSVP"
+      },
+      "url": "https://www.facebook.com/events/"
+    },
+    {
+      "title": {
+        "es": "Nuevas historias en Instagram",
+        "en": "New stories on Instagram"
+      },
+      "description": {
+        "es": "Descubre los detrás de cámaras de la cocina y participa en encuestas sobre tus platillos favoritos.",
+        "en": "Peek behind the kitchen pass and vote in polls for your favorite dishes."
+      },
+      "url": "https://www.instagram.com/gerenibar"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
 </script>
 <script defer="" src="scripts/headerControls.js">
 </script>
+<script defer="" src="scripts/homeHighlights.js">
+</script>
 <script defer="" src="scripts/pdfLink.js">
 </script>
 <script defer="" src="scripts/swRegister.js">
@@ -104,6 +106,26 @@
 <img alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-en="Gereni Bar &amp; Restaurant logo" data-i18n-es="Logo de Gereni Bar y Restaurante" src="assets/logo-gereni-bar-restaurant.png"/>
 </header>
 <main>
+<div class="home-hero">
+<article class="home-highlights" data-home-highlights="">
+<h2 data-i18n-es="Destacados de la casa" data-i18n-en="House highlights">
+      Destacados de la casa
+     </h2>
+<section class="home-highlights__section" data-highlights-section="specials">
+<h3 data-i18n-es="Menús especiales" data-i18n-en="Special menus">
+        Menús especiales
+       </h3>
+<ul class="home-highlights__list" data-highlights-list="specials">
+       </ul>
+      </section>
+<section class="home-highlights__section" data-highlights-section="social">
+<h3 data-i18n-es="Novedades en redes" data-i18n-en="Social updates">
+        Novedades en redes
+       </h3>
+<ul class="home-highlights__list" data-highlights-list="social">
+       </ul>
+      </section>
+     </article>
 <div class="home-panel">
 <div class="cta">
 <a class="btn" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu" href="menu.html">
@@ -119,6 +141,7 @@
 <a class="facebook-link" data-i18n-en="Open Facebook" data-i18n-es="Abrir Facebook" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
       Abrir Facebook
      </a>
+</div>
 </div>
 </div>
 </main>

--- a/scripts/homeHighlights.js
+++ b/scripts/homeHighlights.js
@@ -1,0 +1,175 @@
+(function() {
+  const DATA_URL = 'data/home-highlights.json';
+  const MESSAGE_COPY = {
+    specials: {
+      empty: {
+        es: 'No hay especiales disponibles por ahora.',
+        en: 'No specials available right now.'
+      }
+    },
+    social: {
+      empty: {
+        es: 'Pronto compartiremos novedades desde nuestras redes.',
+        en: 'We will share fresh updates from our social feeds soon.'
+      }
+    },
+    error: {
+      es: 'No se pudieron cargar las novedades. Intenta de nuevo más tarde.',
+      en: 'Highlights could not be loaded. Please try again later.'
+    },
+    loading: {
+      es: 'Cargando destacados…',
+      en: 'Loading highlights…'
+    },
+    fallbackCta: {
+      es: 'Ver detalles',
+      en: 'View details'
+    }
+  };
+
+  const sections = {
+    specials: document.querySelector('[data-highlights-list="specials"]'),
+    social: document.querySelector('[data-highlights-list="social"]')
+  };
+
+  const card = document.querySelector('[data-home-highlights]');
+  if (!card || !sections.specials || !sections.social) {
+    return;
+  }
+
+  let highlightData = null;
+  let hasError = false;
+
+  function getCurrentLang() {
+    const langFromApi = window.GereniLang && typeof window.GereniLang.getCurrent === 'function'
+      ? window.GereniLang.getCurrent()
+      : null;
+    if (langFromApi) return langFromApi;
+    const docLang = document.documentElement.getAttribute('lang');
+    return docLang === 'en' ? 'en' : 'es';
+  }
+
+  function createMessageItem(type, lang, listKey) {
+    const item = document.createElement('li');
+    item.className = `home-highlights__${type}`;
+    let text;
+    if (type === 'error') {
+      text = MESSAGE_COPY.error[lang] || MESSAGE_COPY.error.es;
+    } else if (type === 'empty') {
+      text = MESSAGE_COPY[listKey].empty[lang] || MESSAGE_COPY[listKey].empty.es;
+    } else {
+      text = MESSAGE_COPY.loading[lang] || MESSAGE_COPY.loading.es;
+    }
+    item.textContent = text;
+    return item;
+  }
+
+  function renderList(listKey, lang) {
+    const listEl = sections[listKey];
+    if (!listEl) return;
+    listEl.innerHTML = '';
+
+    if (hasError) {
+      listEl.appendChild(createMessageItem('error', lang, listKey));
+      return;
+    }
+
+    const entries = Array.isArray(highlightData?.[listKey === 'specials' ? 'specialMenus' : 'socialUpdates'])
+      ? highlightData[listKey === 'specials' ? 'specialMenus' : 'socialUpdates']
+      : [];
+
+    if (!entries.length) {
+      listEl.appendChild(createMessageItem('empty', lang, listKey));
+      return;
+    }
+
+    entries.forEach(entry => {
+      const title = entry?.title?.[lang] || entry?.title?.es || '';
+      const description = entry?.description?.[lang] || entry?.description?.es || '';
+      const url = typeof entry?.url === 'string' ? entry.url : '#';
+      const cta = entry?.ctaLabel?.[lang] || entry?.ctaLabel?.es || MESSAGE_COPY.fallbackCta[lang] || MESSAGE_COPY.fallbackCta.es;
+      const price = entry?.price;
+
+      const item = document.createElement('li');
+      item.className = 'home-highlights__item';
+
+      const titleEl = document.createElement('div');
+      titleEl.className = 'home-highlights__title';
+      titleEl.textContent = title || cta;
+      item.appendChild(titleEl);
+
+      if (description) {
+        const descriptionEl = document.createElement('p');
+        descriptionEl.className = 'home-highlights__description';
+        descriptionEl.textContent = description;
+        item.appendChild(descriptionEl);
+      }
+
+      if (price) {
+        const priceEl = document.createElement('span');
+        priceEl.className = 'home-highlights__meta';
+        priceEl.textContent = price;
+        item.appendChild(priceEl);
+      }
+
+      if (url && url !== '#') {
+        const linkEl = document.createElement('a');
+        linkEl.className = 'home-highlights__link';
+        linkEl.href = url;
+        linkEl.rel = 'noopener';
+        linkEl.target = '_blank';
+        linkEl.textContent = cta;
+        item.appendChild(linkEl);
+      }
+
+      listEl.appendChild(item);
+    });
+  }
+
+  function renderAll(lang) {
+    const targetLang = lang || getCurrentLang();
+    renderList('specials', targetLang);
+    renderList('social', targetLang);
+  }
+
+  function setLoadingState() {
+    const lang = getCurrentLang();
+    Object.keys(sections).forEach(key => {
+      const listEl = sections[key];
+      if (!listEl) return;
+      listEl.innerHTML = '';
+      listEl.appendChild(createMessageItem('loading', lang, key));
+    });
+  }
+
+  async function loadHighlights() {
+    setLoadingState();
+    try {
+      const response = await fetch(DATA_URL, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      highlightData = data;
+      hasError = false;
+    } catch (error) {
+      console.error('Error loading home highlights', error);
+      hasError = true;
+    }
+    renderAll();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', loadHighlights);
+  } else {
+    loadHighlights();
+  }
+
+  if (window.GereniLang && typeof window.GereniLang.subscribe === 'function') {
+    window.GereniLang.subscribe(renderAll);
+  } else {
+    document.addEventListener('gereni:languagechange', event => {
+      renderAll(event?.detail?.lang);
+    });
+  }
+})();

--- a/styles/main.css
+++ b/styles/main.css
@@ -7,6 +7,9 @@
   --gereni-muted:#6B625A;
   --gereni-line:#C9B7A4;
   --card-shadow:0 32px 60px rgba(91,58,41,0.16);
+  --home-highlight-bg:rgba(243,232,213,0.78);
+  --home-highlight-border:rgba(91,58,41,0.28);
+  --home-highlight-chip:rgba(91,58,41,0.12);
 }
 
 :root[data-theme="dark"] {
@@ -18,6 +21,9 @@
   --gereni-muted:#B0A69C;
   --gereni-line:rgba(234,215,192,0.24);
   --card-shadow:0 20px 48px rgba(0,0,0,0.36);
+  --home-highlight-bg:rgba(25,24,22,0.78);
+  --home-highlight-border:rgba(234,215,192,0.25);
+  --home-highlight-chip:rgba(234,215,192,0.12);
 }
 
 :root[data-theme="light"] {
@@ -29,6 +35,9 @@
   --gereni-muted:#6B625A;
   --gereni-line:#C9B7A4;
   --card-shadow:0 32px 60px rgba(91,58,41,0.16);
+  --home-highlight-bg:rgba(243,232,213,0.78);
+  --home-highlight-border:rgba(91,58,41,0.28);
+  --home-highlight-chip:rgba(91,58,41,0.12);
 }
 
 * {
@@ -81,6 +90,120 @@ body.inicio main {
   box-sizing:border-box;
 }
 
+.home-hero {
+  display:flex;
+  flex-direction:column;
+  gap:1.75rem;
+  width:100%;
+  max-width:min(1040px, 100%);
+  margin:0 auto;
+  position:relative;
+  z-index:1;
+}
+
+.home-highlights {
+  background:var(--home-highlight-bg);
+  border:1px solid var(--home-highlight-border);
+  border-radius:24px;
+  padding:1.75rem clamp(1.25rem, 4vw, 2rem);
+  box-shadow:var(--card-shadow);
+  backdrop-filter:blur(8px);
+  color:var(--gereni-text);
+  text-align:left;
+  display:flex;
+  flex-direction:column;
+  gap:1.75rem;
+}
+
+.home-highlights h2,
+.home-highlights h3 {
+  color:var(--gereni-brown);
+  margin:0;
+}
+
+.home-highlights h2 {
+  font-size:clamp(1.5rem, 3vw, 2rem);
+}
+
+.home-highlights h3 {
+  font-size:clamp(1.1rem, 2.2vw, 1.3rem);
+  letter-spacing:0.01em;
+}
+
+.home-highlights__section {
+  display:flex;
+  flex-direction:column;
+  gap:0.9rem;
+}
+
+.home-highlights__list {
+  display:flex;
+  flex-direction:column;
+  gap:0.85rem;
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+
+
+.home-highlights__item {
+  background:var(--home-highlight-chip);
+  border-radius:18px;
+  padding:0.9rem 1rem;
+  display:flex;
+  flex-direction:column;
+  gap:0.5rem;
+  border:1px solid transparent;
+}
+
+.home-highlights__title {
+  font-weight:700;
+  font-size:1.05rem;
+  letter-spacing:0.01em;
+}
+
+.home-highlights__description {
+  margin:0;
+  color:var(--gereni-muted);
+  font-size:0.96rem;
+  line-height:1.45;
+}
+
+.home-highlights__link {
+  align-self:flex-start;
+  color:var(--gereni-green);
+  font-weight:600;
+  text-decoration:none;
+  display:inline-flex;
+  align-items:center;
+  gap:0.35rem;
+  font-size:0.95rem;
+}
+
+.home-highlights__link::after {
+  content:'\2192';
+  font-size:0.95rem;
+  line-height:1;
+}
+
+.home-highlights__link:hover,
+.home-highlights__link:focus-visible {
+  text-decoration:underline;
+}
+
+.home-highlights__meta {
+  font-size:0.95rem;
+  color:var(--gereni-muted);
+}
+
+.home-highlights__empty,
+.home-highlights__error,
+.home-highlights__loading {
+  font-size:0.95rem;
+  color:var(--gereni-muted);
+  font-style:italic;
+}
+
 .home-panel {
   background-color:rgba(243,232,213,0.92);
   border-radius:24px;
@@ -91,8 +214,7 @@ body.inicio main {
   display:flex;
   flex-direction:column;
   gap:1.25rem;
-  margin-left:auto;
-  margin-right:clamp(0.5rem, 3vw, 36px);
+  margin:0 auto;
   text-align:center;
 }
 
@@ -315,6 +437,39 @@ body.inicio header::after {
 .facebook-button {
   display:flex;
   justify-content:center;
+}
+
+.home-panel,
+.home-highlights {
+  isolation:isolate;
+}
+
+@media (min-width: 880px) {
+  .home-hero {
+    flex-direction:row;
+    align-items:stretch;
+    gap:2rem;
+  }
+
+  .home-highlights {
+    flex:1 1 0;
+    min-width:0;
+  }
+
+  .home-panel {
+    margin:0;
+    align-self:flex-end;
+  }
+}
+
+@media (max-width: 640px) {
+  .home-highlights {
+    padding:1.5rem 1.25rem;
+  }
+
+  .home-highlights__item {
+    padding:0.85rem 0.9rem;
+  }
 }
 
 .link-download {


### PR DESCRIPTION
## Summary
- wrap the home hero content in a new layout container that introduces the highlights card alongside the existing panel
- theme the highlights card with responsive two-column styles and reusable variables to match the hero backdrop
- add a JSON highlights data source and language-aware script that renders specials and social updates with fallbacks

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_68fc619768048323b735dc289fb2ad1d