### PR TITLE
Replace Puppeteer timeout with generic delay

### DIFF
--- a/tools/export-menu.js
+++ b/tools/export-menu.js
@@ -219,7 +219,7 @@ async function preparePdfLayout(page, resources, lang) {
     throw new Error('No se pudo preparar el layout PDF automáticamente.');
   }
 
-  await page.waitForTimeout(50);
+  await new Promise(resolve => setTimeout(resolve, 50));
 }
 
 async function resetPdfLayout(page) {


### PR DESCRIPTION
## Summary
- update the PDF export script to use a generic setTimeout-based delay instead of Puppeteer's waitForTimeout

## Testing
- npm run export:menu

------
https://chatgpt.com/codex/tasks/task_e_68fc6f6bde048323bf3b275b0cfbea7e