### PR TITLE
Add contributor onboarding checklist documentation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -15,6 +15,7 @@
 | PDF export workflow (`npm run export:menu`, GitHub Actions) | ✅ Complete | Diseño/Maquetación + Soporte técnico | Print and digital PDFs exported to `output/`; automation described in README and workflow guidelines.【F:README.md†L33-L40】【F:workflow.md†L21-L28】 |
 | Canva template governance | ✅ Complete | Diseño/Maquetación | Template access and licensing documented under `design/canva/`.【F:README.md†L16-L18】 |
 | Operational playbook | ✅ Complete | Soporte técnico | Roles, branching strategy, emergency playbook captured in `workflow.md`.【F:workflow.md†L1-L43】 |
+| Contributor onboarding checklist | ✅ Complete | Soporte técnico | `docs/contributor-onboarding.md` published and linked from README for new collaborators.【F:docs/contributor-onboarding.md†L1-L49】【F:README.md†L8-L33】 |
 
 ## 3. Outstanding Work & Roadmap
 
@@ -35,7 +36,6 @@
 | Task | Owner | Priority | Acceptance Criteria | References |
 | --- | --- | --- | --- | --- |
 | Document release cadence aligned with tag convention `vYYYY.MM.menu`. | Soporte técnico | Medium | `workflow.md` updated with calendar, `handoff.md` references release cadence, tags applied during releases. | `workflow.md`, `handoff.md`. |
-| Publish contributor onboarding checklist summarizing editing, testing, and export steps. | Soporte técnico | High | New doc under `docs/` outlining prerequisites, branch strategy, and QA steps; linked from README. | `docs/`, `README.md`, `workflow.md`. |
 | Capture print vendor specs (bleed, color profile) for PDF exports. | Diseño/Maquetación | Medium | `design/` subfolder contains vendor requirements and is referenced from `README.md` and export instructions. | `design/`, `output/`. |
 
 ## 4. Dependencies & Cross-Team Touchpoints
@@ -44,8 +44,8 @@
 - **Deployment artifacts:** Ensure GitHub Actions pipeline remains aligned with export scripts (`tools/export-menu.js`) and storage in `output/`.
 
 ## 5. Next Steps
-1. Prioritize high-impact automation tasks (unit tests for sync script, onboarding checklist).
+1. Prioritize high-impact automation tasks, starting with unit tests for `tools/sync-menu.js`.
 2. Schedule cross-functional review covering seasonal content updates and export cadence.
-3. Track progress using issue templates tied to roadmap sections and update `IMPLEMENTATION_PLAN.md` as milestones close.
+3. Track progress using issue templates tied to roadmap sections and update `IMPLEMENTATION_PLAN.md` as milestones close, calling out dependencies like release cadence documentation and print vendor specs.
 
 > For deeper context, consult `workflow/` for operational reminders, `design/` for visual assets, and `docs/` for technical guides.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ tools/validate-prices.js → Valida que los precios sigan el formato `₡0.000`
 design/canva/licenses/README.md → Registro detallado de licencias y evidencias  
 workflow/reminders.md → Agenda propuesta para recordatorios operativos
 docs/extract-images-from-pdf.md → Guía para extraer y limpiar fotos del menú original
+docs/contributor-onboarding.md → Checklist de incorporación para nuevas personas colaboradoras
 
 ## ⚙️ Requisitos
 
@@ -26,7 +27,7 @@ docs/extract-images-from-pdf.md → Guía para extraer y limpiar fotos del menú
 
 ## ✏️ Cómo editar el menú
 
-1. Abre `content/menu.md` y actualiza nombres, precios o descripciones (formato `₡5.650`). Para gestionar los especiales y novedades de la portada, sigue la guía de `docs/home-highlights.md` que explica el flujo distinto para `data/home-highlights.json`.
+1. Abre `content/menu.md` y actualiza nombres, precios o descripciones (formato `₡5.650`). Para una guía paso a paso del flujo completo (ramas, pruebas y exportaciones), consulta `docs/contributor-onboarding.md`. Para gestionar los especiales y novedades de la portada, sigue la guía de `docs/home-highlights.md` que explica el flujo distinto para `data/home-highlights.json`.
 2. Ejecuta `node tools/sync-menu.js` para regenerar `data/menu.json`.
 3. Ejecuta `npm run check:all` (valida precios y render).
 4. Haz commit y sube los cambios.

--- a/docs/contributor-onboarding.md
+++ b/docs/contributor-onboarding.md
@@ -1,0 +1,49 @@
+# Contributor Onboarding Checklist
+
+> Usa esta guía rápida para preparar tu entorno, proponer cambios y entregar el menú listo para publicar.
+
+## 1. Preparación del entorno
+- **Clonar y crear rama:**
+  1. `git clone https://github.com/sandgraal/gereni-menu.git`
+  2. `cd gereni-menu`
+  3. `git checkout -b feature/<nombre-corto>`
+- **Instalar dependencias:**
+  - `npm ci`
+  - (Opcional) `python -m venv .venv && source .venv/bin/activate` si ejecutarás utilidades en `tools/qr/`.
+- **Revisar documentación clave:**
+  - `workflow.md` para roles, checklist operativo y flujo de publicación.
+  - `design/canva/template-link.md` para confirmar acceso a plantillas.
+
+## 2. Actualizar contenido
+- Edita `content/menu.md` siguiendo el formato bilingüe `Texto ES | Text EN` y precios `₡0.000`.
+- Si necesitas resaltar novedades en la portada, sincroniza los datos con la guía `docs/home-highlights.md`.
+- Ejecuta `node tools/sync-menu.js` para regenerar `data/menu.json`.
+- Si agregas imágenes o íconos, coloca los archivos en `assets/` y documenta licencias en `assets/README.md` o `design/canva/licenses/` según corresponda.
+
+## 3. Validar cambios
+- `npm run check:all` — Ejecuta validadores de precios y pruebas de render.
+- Revisar `data/menu.json` para confirmar que la salida coincide con el Markdown.
+- Abrir `menu.html` en un navegador local (`npx http-server .` o alternativa) para revisar la vista bilingüe.
+
+## 4. Exportar artefactos
+- `npm run export:menu` para generar PDFs en `output/`.
+- Verifica que los nombres de archivos incluyan idioma/tema correcto y que el enlace QR apunte a la URL vigente.
+- Adjunta cualquier especificación de imprenta nueva en `design/` y referencia los cambios en la nota de commit.
+
+## 5. Checklist antes del PR
+- Confirmar que los cambios están en tu rama feature (`git status`).
+- Ejecutar `npm run check:all` nuevamente si editaste después de la primera corrida.
+- `git commit -am "feat: <resumen corto>"` y `git push`.
+- Crear el Pull Request usando la plantilla del repositorio, enlazando a issues relevantes y describiendo pruebas.
+- Marcar en `workflow/reminders.md` cualquier tarea programada (por ejemplo, actualizar QR o revisar licencias) si aplicó.
+
+## 6. Revisión y despliegue
+- Resuelve comentarios del PR asegurando que los scripts (`tools/sync-menu.js`, `tools/validate-prices.js`) sigan pasando.
+- Tras el merge a `main`, confirma en GitHub Actions que el flujo **Update Menu Artifacts** concluyó sin errores.
+- Publica la nueva versión siguiendo la convención de tags `vYYYY.MM.menu` y actualiza `handoff.md` con un resumen.
+
+## Recursos rápidos
+- `README.md` — Estructura del repositorio y comandos principales.
+- `workflow/reminders.md` — Cronograma de tareas periódicas.
+- `docs/extract-images-from-pdf.md` — Guía para optimizar imágenes heredadas.
+- `docs/home-highlights.md` — Procedimiento para la sección de destacados en portada.


### PR DESCRIPTION
## Summary
- add a contributor onboarding checklist that walks newcomers through environment setup, content editing, QA, and release tasks
- surface the new checklist from the README so editors can find it quickly
- update the implementation plan to mark the onboarding checklist task complete and highlight the remaining priorities

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fc7240aee88323bcf59afa36eb3e21