### PR TITLE
Simplify hero highlight card and adjust hero spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,16 +105,13 @@
 </header>
 <main>
 <div class="home-hero">
-<article class="home-highlights">
-<div class="home-highlights__header">
-<p class="home-highlights__eyebrow" data-i18n-es="Este semana en el rancho" data-i18n-en="Este semana en el rancho">
+ <article class="home-highlights">
+  <div class="home-highlights__header">
+   <p class="home-highlights__eyebrow" data-i18n-es="Este semana en el rancho" data-i18n-en="Este semana en el rancho">
         Este semana en el rancho
        </p>
-      </div>
-<figure class="home-highlights__feature">
-<img alt="Especial de la semana: entraña a la parrilla con chimichurri y papas rústicas" class="home-highlights__image" data-i18n-attr="alt" data-i18n-en="Weekly special: grilled flank steak with chimichurri and rustic potatoes" data-i18n-es="Especial de la semana: entraña a la parrilla con chimichurri y papas rústicas" src="assets/photos/esta-semana-el-rancho.svg"/>
-      </figure>
-     </article>
+  </div>
+ </article>
 <div class="home-panel">
 <div class="cta">
 <a class="btn" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu" href="menu.html">

--- a/styles/main.css
+++ b/styles/main.css
@@ -98,23 +98,23 @@ body.inicio main {
   justify-content:center;
   align-items:flex-start;
   width:100%;
-  padding:clamp(3rem, 12vh, 6.5rem) clamp(1.5rem, 5vw, 3rem) clamp(2.5rem, 8vh, 4rem);
-  margin-top:clamp(-5.5rem, -14vh, -3rem);
+  padding:clamp(2.5rem, 10vh, 5.5rem) clamp(1.5rem, 5vw, 3rem) clamp(2.5rem, 8vh, 4rem);
+  margin-top:clamp(1rem, 4vh, 2.5rem);
   box-sizing:border-box;
 }
 
 @media (max-width: 720px) {
   body.inicio main {
-    margin-top:clamp(-3.5rem, -14vw, -2rem);
-    padding-top:clamp(3rem, 18vw, 4.5rem);
+    margin-top:clamp(0.75rem, 6vw, 1.5rem);
+    padding-top:clamp(2.5rem, 18vw, 4rem);
     padding-bottom:clamp(2.25rem, 16vw, 3.5rem);
   }
 }
 
 @media (max-width: 520px) {
   body.inicio main {
-    margin-top:-1.5rem;
-    padding-top:clamp(2.75rem, 24vw, 3.75rem);
+    margin-top:clamp(0.5rem, 8vw, 1.25rem);
+    padding-top:clamp(2.25rem, 24vw, 3.5rem);
   }
 }
 
@@ -146,15 +146,17 @@ body.inicio main {
   background:var(--home-highlight-bg);
   border:1px solid var(--home-highlight-border);
   border-radius:28px;
-  padding:clamp(2rem, 4vw, 2.5rem);
+  padding:clamp(1.5rem, 3vw, 2rem);
   box-shadow:var(--card-shadow);
   backdrop-filter:blur(12px);
   color:var(--gereni-text);
   text-align:left;
   display:flex;
   flex-direction:column;
-  gap:clamp(1.5rem, 3vw, 2.1rem);
+  gap:clamp(0.75rem, 2vw, 1.25rem);
   overflow:hidden;
+  width:min(100%, 420px);
+  justify-self:start;
 }
 
 .home-highlights::before,


### PR DESCRIPTION
## Summary
- remove the weekly special figure so the hero highlight only displays the “Este semana en el rancho” eyebrow
- tighten hero highlight padding and gap while capping its width to keep the card smaller
- adjust main layout margins to drop the hero cards lower and reveal more of the ranch background image

## Testing
- npm run check:all *(fails: social link validation cannot reach external hosts and reports missing data/home-highlights.json)*

------
https://chatgpt.com/codex/tasks/task_e_69001d196e348323bf7b562beec71728