### PR TITLE
Restore accessible description of weekly promo price

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         Este Semana en el Rancho
        </p>
   <img alt="Tarjeta promocional de lasaña con vino tinto" aria-describedby="home-highlight-promo-desc" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos/esta-semana-lasagna-vino.svg"/>
-  <span id="home-highlight-promo-desc" class="sr-only" data-i18n-es="Promoción: Lasaña ₡4.500. Oferta válida hasta el domingo." data-i18n-en="Special: Lasagna ₡4,500. Offer valid through Sunday.">Promoción: Lasaña ₡4.500. Oferta válida hasta el domingo.</span>
+  <span id="home-highlight-promo-desc" class="sr-only" data-i18n-es="Promoción: Lasaña ₡4,500. Oferta válida hasta el domingo." data-i18n-en="Special: Lasagna ₡4,500. Offer valid through Sunday.">Promoción: Lasaña ₡4,500. Oferta válida hasta el domingo.</span>
  </article>
  <div class="home-panel">
   <div class="cta">


### PR DESCRIPTION
Restores a visually-hidden localized description for the weekly promo image so screen readers announce the price (₡4,500) and that the offer ends Sunday. This mirrors the visual poster content and improves accessibility for screen-reader users.