### PR TITLE
Update home hero promo to lasagna PNG

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
   <p class="home-highlights__title" data-i18n-es="Está semana en el Rancho" data-i18n-en="This week at El Rancho">
         Está semana en el Rancho
        </p>
-  <img alt="Tarjeta promocional de lasaña con vino tinto" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos%20/Está-semana-lasagna-vino.png"/>
+  <img alt="Tarjeta promocional de lasaña con vino tinto" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos/Está-semana-lasagna-vino.png"/>
  </article>
  <div class="home-panel">
   <div class="cta">


### PR DESCRIPTION
## Summary
- swap the home page promo art to use the new lasagna PNG asset and update its copy
- simplify the left hero pane so it only shows the requested headline and image

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_69004b22f83c8323bb7d2343038a21d0