### PR TITLE
Refine menu render check to avoid heavy jsdom execution

### DIFF
--- a/tools/check-menu-render.js
+++ b/tools/check-menu-render.js
@@ -73,9 +73,12 @@ async function main() {
 
   const sectionSummaries = sections.map((section, index) => {
     const titles = extractLocalizedText(section?.title || {});
-    const displayTitle = titles.es || titles.en || `Sección ${index + 1}`;
+    const displayTitle =
+      (titles.es && titles.es.trim()) ? titles.es.trim()
+      : (titles.en && titles.en.trim()) ? titles.en.trim()
+      : `Sección ${index + 1}`;
     const items = Array.isArray(section?.items) ? section.items : [];
-    return { title: displayTitle.trim() || `Sección ${index + 1}`, count: items.length };
+    return { title: displayTitle, count: items.length };
   });
 
   const formattedUpdated = formatUpdatedAt(menuData.updatedAt);


### PR DESCRIPTION
## Summary
- replace the menu rendering check with lightweight validations over menu.html and data/menu.json
- log the number of sections and their item counts without instantiating a heavy jsdom DOM
- keep schema and updated-at reporting while ensuring required HTML hooks exist

## Testing
- npm run check:menu
- npm run check:all *(fails: social link validation cannot reach external hosts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69004dd009588323811fe062f314ada4