### PR TITLE
Add accessible description for promo highlight image

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,15 @@
   <p class="home-highlights__title" data-i18n-es="Está semana en el Rancho" data-i18n-en="This week at El Rancho">
         Está semana en el Rancho
        </p>
-  <img alt="Tarjeta promocional de lasaña con vino tinto" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos/Está-semana-lasagna-vino.png"/>
+  <img alt="Tarjeta promocional de lasaña con vino tinto" aria-describedby="promo-details" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos/Está-semana-lasagna-vino.png"/>
+  <span
+    class="sr-only"
+    id="promo-details"
+    data-i18n-es="Promoción: Lasaña con vino tinto por ₡5.500 disponible hasta el domingo."
+    data-i18n-en="Special: Lasagna with red wine for ₡5.500 available through Sunday."
+  >
+        Promoción: Lasaña con vino tinto por ₡5.500 disponible hasta el domingo.
+       </span>
  </article>
  <div class="home-panel">
   <div class="cta">


### PR DESCRIPTION
## Summary
- add an aria-describedby attribute to the promo highlight image
- provide a bilingual sr-only description that covers price and deadline details for screen readers

## Testing
- npm run test:a11y
- npm run check:all (fails: social link validation cannot reach external hosts in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6900563e96dc8323bed03c818ebf6fcc