### PR TITLE
Handle Puppeteer reload timeouts when exporting print menu

### DIFF
--- a/tools/export-menu.js
+++ b/tools/export-menu.js
@@ -269,14 +269,14 @@ async function reloadPageWithFallback(page, primaryOptions, fallbackOptions) {
 
     const isDocumentReady = await page.evaluate(() => {
       const state = document.readyState;
-      return state === 'complete' || state === 'interactive';
+      return state === 'complete';
     });
 
     if (!isDocumentReady) {
       throw error;
     }
 
-    console.warn('Continuing because the document is already interactive.');
+    console.warn('Continuing because the document is already complete.');
   }
 }
 


### PR DESCRIPTION
## Summary
- add a reload helper that falls back when Puppeteer times out waiting for `networkidle0`
- retry the print export navigation with a looser wait condition so the script can continue once the page is ready

## Testing
- ⚠️ `PUPPETEER_DISABLE_SANDBOX=true npm run export:menu` *(fails in the container because Chromium dependencies such as libatk are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_690058746d848323a267843cf243a8f0