### PR TITLE
Handle Puppeteer timeout when exporting print menu

### DIFF
--- a/tools/export-menu.js
+++ b/tools/export-menu.js
@@ -243,7 +243,7 @@ async function waitForDocumentState(page, allowedStates, { timeout = 5000, inter
   const deadline = Date.now() + Math.max(timeout, 0);
   const safeInterval = Math.max(interval, 50);
 
-  while (Date.now() <= deadline) {
+  while (Date.now() < deadline) {
     const state = await page.evaluate(() => document.readyState);
     if (normalizedStates.includes(state)) {
       return state;


### PR DESCRIPTION
## Summary
- add a document-state polling helper for Puppeteer navigation retries
- continue the print export when reload waits time out but the page is already ready

## Testing
- npm run export:menu *(fails locally: missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_69005a8a74d483238ec220e2274d1c10