### PR TITLE
Refine home page layout and dropdown behavior

### DIFF
--- a/assets/icons/download.svg
+++ b/assets/icons/download.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 4v10.5" stroke="#4B6A3D" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="m8.5 11.5 3.5 3.75 3.5-3.75" stroke="#4B6A3D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 16.5h11a1.5 1.5 0 0 1 0 3h-11a1.5 1.5 0 0 1 0-3Z" stroke="#4B6A3D" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/facebook.svg
+++ b/assets/icons/facebook.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M14.5 5.5h2V3h-2c-2.485 0-4 1.514-4 4v2H8v2.5h2.5V21h3V11.5H16L16.5 9H13v-1.9c0-.9.35-1.6 1.5-1.6Z" fill="#3B5998"/>
+</svg>

--- a/assets/icons/menu-book.svg
+++ b/assets/icons/menu-book.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M5 4.5C5 3.672 5.672 3 6.5 3h9a2.5 2.5 0 0 1 2.5 2.5V20a1 1 0 0 1-1.447.894L12 18.118l-4.553 2.776A1 1 0 0 1 6 20V4.5Z" stroke="#4B6A3D" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M9 8h6M9 11.5h6" stroke="#4B6A3D" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -111,9 +111,12 @@
    data-i18n-es="Está semana en el Rancho"
    data-i18n-en="This week at El Rancho"
  >
-  <p class="home-highlights__title" data-i18n-es="Está semana en el Rancho" data-i18n-en="This week at El Rancho">
-        Está semana en el Rancho
-       </p>
+  <div class="home-highlights__header">
+   <p class="home-highlights__title" data-i18n-es="Está semana en el Rancho" data-i18n-en="This week at El Rancho">
+          Está semana en el Rancho
+         </p>
+   <img alt="" aria-hidden="true" class="home-highlights__badge" src="assets/icons/toucan.svg"/>
+  </div>
   <img alt="Tarjeta promocional de lasaña con vino tinto" aria-describedby="promo-details" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos/esta-semana-lasagna-vino.png"/>
   <span
     class="sr-only"
@@ -126,24 +129,35 @@
  </article>
  <div class="home-panel">
   <div class="cta">
-   <a class="btn" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu" href="menu.html">
-      Ver el Menú
-     </a>
+   <a class="btn btn--with-icon" href="menu.html">
+    <img alt="" aria-hidden="true" class="btn__icon" src="assets/icons/menu-book.svg"/>
+    <span data-i18n-es="Ver el Menú" data-i18n-en="View the Menu">
+          Ver el Menú
+         </span>
+   </a>
   </div>
   <div class="secondary-links">
-   <a class="link-download" data-i18n-es="Descargar Menú en PDF" data-i18n-en="Download Menu PDF" href="output/Menu_Gereni_digital_es_dark.pdf" rel="noopener" target="_blank">
-      Descargar Menú en PDF
-     </a>
+   <a class="link-download link-download--with-icon" href="output/Menu_Gereni_digital_es_dark.pdf" rel="noopener" target="_blank">
+    <img alt="" aria-hidden="true" class="link-download__icon" src="assets/icons/download.svg"/>
+    <span data-i18n-es="Descargar Menú en PDF" data-i18n-en="Download Menu PDF">
+          Descargar Menú en PDF
+         </span>
+   </a>
   </div>
   <div class="facebook-button">
-   <a class="facebook-link" data-i18n-en="Open Facebook" data-i18n-es="Abrir Facebook" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
-    Abrir Facebook
+   <a class="facebook-link social-link" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
+    <img alt="" aria-hidden="true" class="social-link__icon" src="assets/icons/facebook.svg"/>
+    <span data-i18n-es="Abrir Facebook" data-i18n-en="Open Facebook">
+          Abrir Facebook
+         </span>
    </a>
   </div>
   <div class="instagram-button">
-   <a class="instagram-link" data-i18n-en="Open Instagram" data-i18n-es="Abrir Instagram" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank">
-    <img alt="" aria-hidden="true" class="instagram-icon" src="assets/icons/instagram.svg"/>
-    Abrir Instagram
+   <a class="instagram-link social-link" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank">
+    <img alt="" aria-hidden="true" class="social-link__icon" src="assets/icons/instagram.svg"/>
+    <span data-i18n-es="Abrir Instagram" data-i18n-en="Open Instagram">
+          Abrir Instagram
+         </span>
    </a>
   </div>
  </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -127,14 +127,14 @@ body.inicio main {
   margin:0 auto;
   position:relative;
   z-index:1;
-  align-items:stretch;
+  align-items:center;
   justify-items:center;
 }
 
 @media (min-width: 720px) {
   .home-hero {
-    grid-template-columns:minmax(0, 1fr) minmax(260px, 320px);
-    justify-items:stretch;
+    grid-template-columns:minmax(0, 1fr) minmax(200px, 240px);
+    justify-items:center;
     align-items:start;
   }
 
@@ -151,11 +151,32 @@ body.inicio main {
   align-items:center;
   gap:clamp(0.75rem, 2.4vw, 1.25rem);
   text-align:center;
-  width:min(100%, 520px);
+  width:min(100%, 380px);
   padding:0;
   background:none;
   border:none;
   box-shadow:none;
+}
+
+@media (min-width: 720px) {
+  .home-highlights {
+    width:min(60vw, 320px);
+  }
+}
+
+.home-highlights__header {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:clamp(0.65rem, 2vw, 1.1rem);
+  flex-wrap:wrap;
+}
+
+.home-highlights__badge {
+  width:clamp(2.25rem, 6vw, 3.25rem);
+  height:auto;
+  display:block;
+  filter:drop-shadow(0 10px 22px rgba(27, 19, 13, 0.2));
 }
 
 .home-highlights__title {
@@ -170,29 +191,45 @@ body.inicio main {
   border-radius:18px;
   padding:0.75rem 1.25rem;
   box-shadow:0 16px 32px rgba(33, 22, 15, 0.16);
+  display:inline-flex;
+  align-items:center;
+  gap:0.5rem;
 }
 
 .home-highlights__poster {
-  width:100%;
-  max-width:600px;
+  width:90%;
+  max-width:420px;
   height:auto;
-  border-radius:28px;
+  border-radius:24px;
   display:block;
-  box-shadow:0 28px 60px rgba(14, 10, 8, 0.42);
+  box-shadow:0 22px 48px rgba(14, 10, 8, 0.38);
+}
+
+@media (max-width: 540px) {
+  .home-highlights__poster {
+    width:100%;
+    max-width:100%;
+  }
 }
 
 .home-panel {
   background-color:rgba(243,232,213,0.92);
   border-radius:24px;
-  padding:1.75rem 1.5rem;
+  padding:1.65rem 1.35rem;
   box-shadow:var(--card-shadow);
-  max-width:320px;
+  max-width:240px;
   width:100%;
   display:flex;
   flex-direction:column;
-  gap:1.25rem;
+  gap:1.1rem;
   margin:0 auto;
   text-align:center;
+}
+
+@media (min-width: 720px) {
+  .home-panel {
+    max-width:min(60vw, 200px);
+  }
 }
 
 h1,
@@ -297,8 +334,9 @@ body.inicio header {
 
 .control-dropdown__panel {
   position:absolute;
-  top:calc(100% + 0.5rem);
-  right:0;
+  top:50%;
+  right:calc(100% + 0.75rem);
+  transform:translateY(-50%) scale(0.96);
   display:flex;
   flex-direction:column;
   gap:1rem;
@@ -310,6 +348,27 @@ body.inicio header {
   box-shadow:0 20px 40px rgba(27,19,13,0.16);
   backdrop-filter:blur(12px);
   z-index:4;
+  transition:transform 0.24s ease, opacity 0.24s ease;
+  opacity:0;
+  pointer-events:none;
+}
+
+@media (max-width: 640px) {
+  .control-dropdown__panel {
+    top:calc(100% + 0.5rem);
+    right:0;
+    transform:none;
+  }
+
+  .control-dropdown.is-open .control-dropdown__panel {
+    transform:none;
+  }
+}
+
+.control-dropdown.is-open .control-dropdown__panel {
+  opacity:1;
+  pointer-events:auto;
+  transform:translateY(-50%) scale(1);
 }
 
 .control-dropdown__panel[hidden] {
@@ -391,6 +450,20 @@ body.inicio header::after {
   text-transform:uppercase;
   transition:transform 0.2s ease, box-shadow 0.2s ease;
   box-shadow:0 12px 24px rgba(75,106,61,0.25);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:0.65rem;
+}
+
+.btn--with-icon {
+  padding:0.9em 2.15em;
+}
+
+.btn__icon {
+  width:1.35rem;
+  height:1.35rem;
+  display:block;
 }
 
 .btn:hover,
@@ -457,6 +530,19 @@ body.inicio header::after {
   border:2px solid var(--gereni-green);
   border-radius:999px;
   transition:background-color 0.2s ease, color 0.2s ease;
+  display:inline-flex;
+  align-items:center;
+  gap:0.55rem;
+}
+
+.link-download--with-icon {
+  padding:0.7rem 1.4rem;
+}
+
+.link-download__icon {
+  width:1.1rem;
+  height:1.1rem;
+  display:block;
 }
 
 .link-download:hover,
@@ -659,6 +745,9 @@ footer {
 .facebook-link,
 .instagram-link {
   align-self:center;
+}
+
+.social-link {
   background-color:var(--gereni-green);
   color:#fff;
   padding:0.65rem 1.5rem;
@@ -672,16 +761,14 @@ footer {
   gap:0.55rem;
 }
 
-.facebook-link:hover,
-.facebook-link:focus-visible,
-.instagram-link:hover,
-.instagram-link:focus-visible {
+.social-link:hover,
+.social-link:focus-visible {
   background-color:var(--gereni-brown);
   color:#fff;
   transform:translateY(-1px);
 }
 
-.instagram-icon {
+.social-link__icon {
   width:1.1rem;
   height:1.1rem;
   flex-shrink:0;
@@ -872,7 +959,8 @@ body[data-theme="dark"].inicio section {
 }
 
 body[data-theme="dark"].inicio .facebook-link,
-body[data-theme="dark"].inicio .instagram-link {
+body[data-theme="dark"].inicio .instagram-link,
+body[data-theme="dark"].inicio .social-link {
   background-color:var(--gereni-brown);
   color:#0f110d;
 }


### PR DESCRIPTION
## Summary
- resize the home hero highlight and CTA panel so they sit comfortably beneath the Rancho background artwork
- reposition the language/style dropdown to open laterally with a softer transition that avoids overlapping hero content
- add custom icons to the primary menu, download, and social links for a livelier front page

## Testing
- npm run check:social *(fails: ENETUNREACH when validating remote social links in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69013bd364e8832388388bf6c12a37c1