### PR TITLE
Remove hero promo and refresh home quick actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,50 +105,29 @@
 </header>
 <main>
 <div class="home-hero">
- <article class="home-highlights"
-   aria-label="Está semana en el Rancho"
-   data-i18n-attr="aria-label"
-   data-i18n-es="Está semana en el Rancho"
-   data-i18n-en="This week at El Rancho"
- >
-  <p class="home-highlights__title" data-i18n-es="Está semana en el Rancho" data-i18n-en="This week at El Rancho">
-        Está semana en el Rancho
-       </p>
-  <img alt="Tarjeta promocional de lasaña con vino tinto" aria-describedby="promo-details" class="home-highlights__poster" data-i18n-attr="alt" data-i18n-en="Promotional card featuring lasagna with red wine" data-i18n-es="Tarjeta promocional de lasaña con vino tinto" src="assets/photos/esta-semana-lasagna-vino.svg"/>
-  <span
-    class="sr-only"
-    id="promo-details"
-    data-i18n-es="Promoción: Lasaña con vino tinto por ₡5.500 disponible hasta el domingo."
-    data-i18n-en="Special: Lasagna with red wine for ₡5.500 available through Sunday."
-  >
-        Promoción: Lasaña con vino tinto por ₡5.500 disponible hasta el domingo.
-       </span>
-</article>
-<div class="home-panel">
- <div class="cta">
-   <a class="btn" href="menu.html" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu">
-        Ver el Menú
-       </a>
-  </div>
-  <div class="secondary-links">
-   <a class="link-download" href="output/Menu_Gereni_digital_es_dark.pdf" rel="noopener" target="_blank" data-i18n-es="Descargar Menú en PDF" data-i18n-en="Download Menu PDF">
-        Descargar Menú en PDF
-       </a>
-  </div>
-  <div class="facebook-button">
-   <a class="facebook-link" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
-    <span data-i18n-es="Abrir Facebook" data-i18n-en="Open Facebook">
+ <div class="home-panel" role="navigation" aria-label="Acciones rápidas" data-i18n-attr="aria-label" data-i18n-es="Acciones rápidas" data-i18n-en="Quick actions">
+  <ul class="home-actions">
+   <li class="home-actions__item">
+    <a class="home-actions__link home-actions__link--primary" href="menu.html" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu">
+          Ver el Menú
+         </a>
+   </li>
+   <li class="home-actions__item">
+    <a class="home-actions__link home-actions__link--secondary link-download" href="output/Menu_Gereni_digital_es_dark.pdf" rel="noopener" target="_blank" data-i18n-es="Descargar Menú en PDF" data-i18n-en="Download Menu PDF">
+          Descargar Menú en PDF
+         </a>
+   </li>
+   <li class="home-actions__item">
+    <a class="home-actions__link home-actions__link--social facebook-link" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank" data-i18n-es="Abrir Facebook" data-i18n-en="Open Facebook">
           Abrir Facebook
-         </span>
-   </a>
-  </div>
-  <div class="instagram-button">
-   <a class="instagram-link" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank">
-    <span data-i18n-es="Abrir Instagram" data-i18n-en="Open Instagram">
+         </a>
+   </li>
+   <li class="home-actions__item">
+    <a class="home-actions__link home-actions__link--social instagram-link" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank" data-i18n-es="Abrir Instagram" data-i18n-en="Open Instagram">
           Abrir Instagram
-         </span>
-   </a>
-  </div>
+         </a>
+   </li>
+  </ul>
  </div>
 </div>
 </main>

--- a/styles/main.css
+++ b/styles/main.css
@@ -119,86 +119,108 @@ body.inicio main {
 }
 
 .home-hero {
-  display:grid;
-  gap:clamp(1.5rem, 4vw, 2.5rem);
-  grid-template-columns:minmax(0, 1fr);
   width:100%;
-  max-width:min(1080px, 100%);
+  max-width:min(1120px, 100%);
   margin:0 auto;
   position:relative;
   z-index:1;
-  align-items:stretch;
-  justify-items:center;
-}
-
-@media (min-width: 720px) {
-  .home-hero {
-    grid-template-columns:minmax(0, 1fr) minmax(260px, 320px);
-    justify-items:stretch;
-    align-items:start;
-  }
-
-  .home-panel {
-    margin:0;
-    align-self:start;
-  }
-}
-
-
-.home-highlights {
   display:flex;
-  flex-direction:column;
-  align-items:center;
-  gap:clamp(0.75rem, 2.4vw, 1.25rem);
-  text-align:center;
-  width:min(100%, 520px);
-  padding:0;
-  background:none;
-  border:none;
-  box-shadow:none;
+  justify-content:center;
+  align-items:flex-start;
+  padding-inline:clamp(0.5rem, 3vw, 1.5rem);
+  box-sizing:border-box;
 }
 
-.home-highlights__title {
-  font-size:clamp(1.2rem, 2.6vw, 1.65rem);
-  letter-spacing:0.08em;
-  font-weight:600;
-  color:var(--gereni-brown);
-  margin:0;
-  text-transform:none;
-  background-color:rgba(243,232,213,0.78);
-  border:1px solid rgba(91,58,41,0.18);
-  border-radius:18px;
-  padding:0.75rem 1.25rem;
-  box-shadow:0 16px 32px rgba(33, 22, 15, 0.16);
-}
-
-.home-highlights__poster {
-  width:100%;
-  max-width:600px;
-  height:auto;
-  border-radius:28px;
-  display:block;
-  box-shadow:0 28px 60px rgba(14, 10, 8, 0.42);
+@media (min-width: 900px) {
+  .home-hero {
+    justify-content:flex-end;
+  }
 }
 
 .home-panel {
-  background-color:rgba(243,232,213,0.92);
-  border-radius:24px;
-  padding:1.75rem 1.5rem;
-  box-shadow:var(--card-shadow);
-  max-width:320px;
-  width:100%;
+  background:linear-gradient(145deg, rgba(243,232,213,0.94), rgba(255,245,232,0.85));
+  border-radius:28px;
+  padding:clamp(1.5rem, 4vw, 2.25rem);
+  box-shadow:0 24px 60px rgba(33, 22, 15, 0.25);
+  width:min(100%, 360px);
   display:flex;
   flex-direction:column;
-  gap:1.25rem;
-  margin:0 auto;
-  text-align:center;
+  justify-content:center;
+  backdrop-filter:blur(10px);
+  border:1px solid rgba(91,58,41,0.14);
+  margin:0;
 }
 
-@media (min-width: 720px) {
-  .home-panel {
-    max-width:min(60vw, 200px);
-  }
+.home-actions {
+  list-style:none;
+  display:flex;
+  flex-direction:column;
+  gap:clamp(0.9rem, 2.5vw, 1.3rem);
+  padding:0;
+  margin:0;
+}
+
+.home-actions__item {
+  display:flex;
+}
+
+.home-actions__link {
+  flex:1;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:1rem clamp(1.25rem, 4vw, 1.75rem);
+  border-radius:20px;
+  font-weight:600;
+  letter-spacing:0.06em;
+  text-transform:uppercase;
+  text-decoration:none;
+  color:var(--gereni-brown);
+  background:linear-gradient(160deg, rgba(255,255,255,0.92), rgba(248,238,223,0.8));
+  box-shadow:0 16px 38px rgba(91,58,41,0.18);
+  position:relative;
+  overflow:hidden;
+  transition:transform 0.25s ease, box-shadow 0.25s ease, background 0.3s ease;
+}
+
+.home-actions__link::after {
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at 20% 20%, rgba(255,255,255,0.35), transparent 65%);
+  opacity:0;
+  transition:opacity 0.35s ease;
+}
+
+.home-actions__link:hover,
+.home-actions__link:focus {
+  transform:translateY(-3px);
+  box-shadow:0 24px 46px rgba(91,58,41,0.24);
+}
+
+.home-actions__link:hover::after,
+.home-actions__link:focus::after {
+  opacity:1;
+}
+
+.home-actions__link--primary {
+  background:linear-gradient(140deg, rgba(75,106,61,0.94), rgba(130,161,112,0.85));
+  color:#fff;
+  box-shadow:0 20px 40px rgba(75,106,61,0.3);
+}
+
+.home-actions__link--primary::after {
+  background:radial-gradient(circle at 25% 25%, rgba(255,255,255,0.5), transparent 60%);
+}
+
+.home-actions__link--secondary {
+  background:linear-gradient(150deg, rgba(255,255,255,0.92), rgba(243,232,213,0.82));
+  border:1px solid rgba(91,58,41,0.18);
+}
+
+.home-actions__link--social {
+  background:linear-gradient(160deg, rgba(255,255,255,0.9), rgba(237,227,211,0.78));
+  border:1px solid rgba(91,58,41,0.15);
 }
 
 h1,
@@ -408,90 +430,8 @@ body.inicio header::after {
   filter:drop-shadow(0 4px 8px rgba(91,58,41,0.18));
 }
 
-.btn {
-  background-color:var(--gereni-green);
-  color:#fff;
-  padding:0.95em 2.4em;
-  border-radius:999px;
-  text-decoration:none;
-  font-weight:600;
-  letter-spacing:0.04em;
-  text-transform:uppercase;
-  transition:transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow:0 12px 24px rgba(75,106,61,0.25);
-  display:inline-block;
-}
-
-.btn:hover,
-.btn:focus {
-  transform:translateY(-2px);
-  box-shadow:0 16px 30px rgba(75,106,61,0.28);
-}
-
-.cta {
-  display:flex;
-  justify-content:center;
-}
-
-.secondary-links {
-  display:flex;
-  gap:1rem;
-  justify-content:center;
-  flex-wrap:wrap;
-}
-
-.facebook-button,
-.instagram-button {
-  display:flex;
-  justify-content:center;
-}
-
-.home-panel,
-.home-highlights {
+.home-panel {
   isolation:isolate;
-}
-
-@media (min-width: 880px) {
-  .home-highlights__grid {
-    grid-template-columns:repeat(2, minmax(0, 1fr));
-  }
-
-  .home-panel {
-    margin:0;
-    align-self:start;
-    position:sticky;
-    top:clamp(3.25rem, 11vh, 4.5rem);
-  }
-}
-
-@media (max-width: 640px) {
-  .home-highlights {
-    padding:1.65rem 1.3rem;
-  }
-
-  .home-highlights__list {
-    grid-template-columns:minmax(0, 1fr);
-  }
-
-  .home-highlights__item {
-    padding:0.95rem 1rem 1.05rem;
-  }
-}
-
-.link-download {
-  color:var(--gereni-green);
-  font-weight:600;
-  text-decoration:none;
-  padding:0.75rem 1.5rem;
-  border:2px solid var(--gereni-green);
-  border-radius:999px;
-  transition:background-color 0.2s ease, color 0.2s ease;
-}
-
-.link-download:hover,
-.link-download:focus {
-  background-color:var(--gereni-green);
-  color:#fff;
 }
 
 body.inicio section {
@@ -845,49 +785,42 @@ body[data-theme="dark"].inicio header {
 }
 
 body[data-theme="dark"].inicio .home-panel {
-  background-color:rgba(19,19,18,0.92);
-  box-shadow:var(--card-shadow);
-  border:1px solid rgba(234,215,192,0.18);
+  background:linear-gradient(145deg, rgba(30,28,26,0.94), rgba(44,41,38,0.82));
+  box-shadow:0 28px 60px rgba(0,0,0,0.5);
+  border:1px solid rgba(234,215,192,0.22);
 }
 
-body[data-theme="dark"].inicio .home-highlights {
-  background-color:rgba(19,19,18,0.92);
-  border:1px solid rgba(234,215,192,0.18);
-  box-shadow:var(--card-shadow);
-}
-
-body[data-theme="dark"].inicio .home-highlights__title {
+body[data-theme="dark"].inicio .home-actions__link {
   color:var(--gereni-text);
+  background:linear-gradient(160deg, rgba(44,41,38,0.92), rgba(36,34,32,0.82));
+  border:1px solid rgba(234,215,192,0.16);
+  box-shadow:0 22px 48px rgba(0,0,0,0.45);
+}
+
+body[data-theme="dark"].inicio .home-actions__link::after {
+  background:radial-gradient(circle at 20% 20%, rgba(234,215,192,0.32), transparent 65%);
+}
+
+body[data-theme="dark"].inicio .home-actions__link--primary {
+  background:linear-gradient(140deg, rgba(130,161,112,0.92), rgba(90,122,74,0.82));
+  color:#101410;
+  box-shadow:0 24px 52px rgba(75,106,61,0.45);
+}
+
+body[data-theme="dark"].inicio .home-actions__link--primary::after {
+  background:radial-gradient(circle at 25% 25%, rgba(255,255,255,0.45), transparent 60%);
+}
+
+body[data-theme="dark"].inicio .home-actions__link--secondary {
+  background:linear-gradient(155deg, rgba(48,45,42,0.96), rgba(37,35,32,0.78));
+}
+
+body[data-theme="dark"].inicio .home-actions__link--social {
+  background:linear-gradient(150deg, rgba(46,43,40,0.94), rgba(37,35,32,0.78));
 }
 
 body[data-theme="dark"].inicio .logo {
   filter:drop-shadow(0 4px 12px rgba(0,0,0,0.45)) drop-shadow(0 0 6px rgba(255,255,255,0.32));
-}
-
-body[data-theme="dark"].inicio .btn {
-  background-color:var(--gereni-brown);
-  color:#0f110d;
-  box-shadow:0 12px 24px rgba(91,58,41,0.32);
-}
-
-body[data-theme="dark"].inicio .btn:hover,
-body[data-theme="dark"].inicio .btn:focus {
-  background-color:var(--gereni-brown);
-  color:#0f110d;
-  box-shadow:0 16px 30px rgba(91,58,41,0.4);
-}
-
-body[data-theme="dark"].inicio .link-download {
-  background-color:var(--gereni-brown);
-  color:#0f110d;
-  border-color:var(--gereni-brown);
-}
-
-body[data-theme="dark"].inicio .link-download:hover,
-body[data-theme="dark"].inicio .link-download:focus {
-  background-color:var(--gereni-brown);
-  color:#0f110d;
-  border-color:var(--gereni-brown);
 }
 
 body[data-theme="dark"].inicio .facebook-card,
@@ -895,12 +828,6 @@ body[data-theme="dark"].inicio section {
   border:1px solid rgba(234,215,192,0.18);
   background:rgba(19,19,18,0.85);
   box-shadow:var(--card-shadow);
-}
-
-body[data-theme="dark"].inicio .facebook-link,
-body[data-theme="dark"].inicio .instagram-link {
-  background-color:var(--gereni-brown);
-  color:#0f110d;
 }
 
 body[data-theme="dark"].inicio .home-link {

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -14,53 +14,42 @@ function test(name, fn) {
 const indexPath = path.join(__dirname, '..', 'index.html');
 const html = fs.readFileSync(indexPath, 'utf8');
 
-test('promo image has aria-describedby attribute', () => {
-  // Check that the promo image has aria-describedby on the same <img> tag
-  // The regex handles both possible attribute orders for robustness
-  const classFirstPattern = /<img[^>]*class=["'][^"']*home-highlights__poster[^"']*["'][^>]*aria-describedby=["']promo-details["'][^>]*>/i;
-  const ariaFirstPattern = /<img[^>]*aria-describedby=["']promo-details["'][^>]*class=["'][^"']*home-highlights__poster[^"']*["'][^>]*>/i;
-  
-  const hasClassAndAria = classFirstPattern.test(html) || ariaFirstPattern.test(html);
-  
+test('home panel exposes a navigation landmark', () => {
+  const panelPattern = /<div[^>]*class=\"home-panel\"[^>]*role=\"navigation\"[^>]*aria-label=\"/i;
+
   assert.ok(
-    hasClassAndAria,
-    'Promo image should have aria-describedby="promo-details" on the same <img> element'
+    panelPattern.test(html),
+    'Home panel should expose role="navigation" with an aria-label for assistive tech'
   );
 });
 
-test('promo description span exists with sr-only class', () => {
-  // Check that the description span exists
+test('quick actions are presented as an unordered list', () => {
+  const listPattern = /<ul[^>]*class=\"home-actions\"[^>]*>[\s\S]*?<\/ul>/i;
+  const itemPattern = /<li[^>]*class=\"home-actions__item\"[^>]*>/i;
+
+  assert.ok(listPattern.test(html), 'Quick actions list <ul class="home-actions"> should exist');
+  assert.ok(itemPattern.test(html), 'Quick actions should use <li class="home-actions__item"> elements');
+});
+
+test('download link keeps dynamic class for PDF swapping', () => {
+  const downloadPattern = /<a[^>]*class=\"[^\"]*link-download[^\"]*\"[^>]*href=\"output\/Menu_Gereni_digital_es_dark.pdf\"[^>]*>/i;
+
   assert.ok(
-    html.includes('id="promo-details"') && html.includes('class="sr-only"'),
-    'Description span should exist with id="promo-details" and class="sr-only"'
+    downloadPattern.test(html),
+    'Download action should keep link-download class so the PDF updater can find it'
   );
 });
 
-test('promo description includes price information', () => {
-  // Check that the description includes price with standard format (₡5.500)
-  assert.ok(
-    html.includes('₡5.500'),
-    'Description should include the price ₡5.500'
-  );
-});
+test('social links remain external and open in a new tab', () => {
+  const socialPattern = /<a[^>]*class=\"[^\"]*home-actions__link--social[^\"]*\"[^>]*>/gi;
+  const matches = html.match(socialPattern) || [];
 
-test('promo description includes deadline information', () => {
-  // Check that the description mentions the deadline (either in Spanish or English)
-  assert.ok(
-    html.includes('domingo') || html.includes('Sunday'),
-    'Description should mention the deadline (domingo/Sunday)'
-  );
-});
+  assert.ok(matches.length >= 2, 'Both social actions should be rendered');
 
-test('promo description has bilingual support', () => {
-  // Check that the description has both Spanish and English versions
-  const hasSpanish = html.includes('data-i18n-es=') && html.includes('Lasaña con vino tinto');
-  const hasEnglish = html.includes('data-i18n-en=') && html.includes('Lasagna with red wine');
-  
-  assert.ok(
-    hasSpanish && hasEnglish,
-    'Description should have both Spanish (data-i18n-es) and English (data-i18n-en) translations'
-  );
+  matches.forEach((match) => {
+    assert.ok(match.includes('target="_blank"'), 'Social actions should use target="_blank"');
+    assert.ok(match.includes('rel="noopener"'), 'Social actions should include rel="noopener"');
+  });
 });
 
 // Run all tests


### PR DESCRIPTION
## Summary
- remove the promotional hero card so the ranch background takes center stage
- restyle the quick actions panel into a single navigation list with animated buttons that scale to desktop and mobile layouts
- update the accessibility smoke tests to cover the new structure and keep the PDF downloader hook intact

## Testing
- npm run test:a11y
- npm run check:social *(fails: missing data/home-highlights.json and network access in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_69014895b6c88323a6f0250f5c24a9f2