### PR TITLE
Refresh home quick actions design

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,28 +106,85 @@
 <main>
 <div class="home-hero">
  <div class="home-panel" role="navigation" aria-label="Acciones rápidas" data-i18n-attr="aria-label" data-i18n-es="Acciones rápidas" data-i18n-en="Quick actions">
-  <ul class="home-actions">
+  <p class="home-panel__eyebrow" data-i18n-es="Planifica tu visita" data-i18n-en="Plan your visit">
+       Planifica tu visita
+      </p>
+  <h2 class="home-panel__title" data-i18n-es="Sabores caseros, ambiente familiar" data-i18n-en="Homestyle flavors, warm hospitality">
+       Sabores caseros, ambiente familiar
+      </h2>
+  <p class="home-panel__subtitle" data-i18n-es="Explora el menú digital o descárgalo para compartirlo al instante." data-i18n-en="Browse the digital menu or download it to share in seconds.">
+       Explora el menú digital o descárgalo para compartirlo al instante.
+      </p>
+  <ul class="home-actions" data-variant="primary">
    <li class="home-actions__item">
-    <a class="home-actions__link home-actions__link--primary" href="menu.html" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu">
-          Ver el Menú
-         </a>
+    <a class="home-actions__link home-actions__link--primary" href="menu.html">
+      <span aria-hidden="true" class="home-actions__icon">
+       <svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
+        <path d="M7 10H25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <path d="M7 16H19" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <path d="M7 22H21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <rect height="20" rx="3" stroke="currentColor" stroke-width="2" width="20" x="6" y="6"/>
+       </svg>
+      </span>
+      <span class="home-actions__content">
+       <span class="home-actions__title" data-i18n-es="Ver el Menú" data-i18n-en="View the Menu">
+            Ver el Menú
+           </span>
+       <span class="home-actions__description" data-i18n-es="Descubre platillos destacados y recomendaciones del chef." data-i18n-en="See featured dishes and chef suggestions.">
+            Descubre platillos destacados y recomendaciones del chef.
+           </span>
+      </span>
+     </a>
    </li>
    <li class="home-actions__item">
-    <a class="home-actions__link home-actions__link--secondary link-download" href="output/Menu_Gereni_digital_es_dark.pdf" rel="noopener" target="_blank" data-i18n-es="Descargar Menú en PDF" data-i18n-en="Download Menu PDF">
-          Descargar Menú en PDF
-         </a>
-   </li>
-   <li class="home-actions__item">
-    <a class="home-actions__link home-actions__link--social facebook-link" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank" data-i18n-es="Abrir Facebook" data-i18n-en="Open Facebook">
-          Abrir Facebook
-         </a>
-   </li>
-   <li class="home-actions__item">
-    <a class="home-actions__link home-actions__link--social instagram-link" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank" data-i18n-es="Abrir Instagram" data-i18n-en="Open Instagram">
-          Abrir Instagram
-         </a>
+    <a class="home-actions__link home-actions__link--secondary link-download" href="output/Menu_Gereni_digital_es_dark.pdf" rel="noopener" target="_blank">
+      <span aria-hidden="true" class="home-actions__icon">
+       <svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
+        <path d="M16 7V21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <path d="M11 16L16 21L21 16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <path d="M9 24H23" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+       </svg>
+      </span>
+      <span class="home-actions__content">
+       <span class="home-actions__title" data-i18n-es="Descargar Menú en PDF" data-i18n-en="Download Menu PDF">
+            Descargar Menú en PDF
+           </span>
+       <span class="home-actions__description" data-i18n-es="Guárdalo sin conexión o compártelo con tu mesa." data-i18n-en="Keep it offline or share it with your table.">
+            Guárdalo sin conexión o compártelo con tu mesa.
+           </span>
+      </span>
+     </a>
    </li>
   </ul>
+  <div class="home-social">
+   <p class="home-social__title" data-i18n-es="Conéctate con nosotros" data-i18n-en="Connect with us">
+        Conéctate con nosotros
+       </p>
+   <div class="home-social__buttons">
+    <a class="home-social__link home-social__link--facebook home-actions__link--social facebook-link" href="https://www.facebook.com/baryrestaurantegereni" rel="noopener" target="_blank">
+      <span aria-hidden="true" class="home-social__icon">
+       <svg fill="currentColor" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+        <path d="M14.5 7.5h2.5V4h-2.9c-3.1 0-4.1 1.9-4.1 4v2H8v3.5h2v7h3.5v-7h2.6l.4-3.5h-3V8.5c0-.6.2-1 1-1z"/>
+       </svg>
+      </span>
+      <span class="home-social__label" data-i18n-es="Abrir Facebook" data-i18n-en="Open Facebook">
+        Abrir Facebook
+       </span>
+     </a>
+    <a class="home-social__link home-social__link--instagram home-actions__link--social instagram-link" href="https://www.instagram.com/baryrestaurantegereni" rel="noopener" target="_blank">
+      <span aria-hidden="true" class="home-social__icon">
+       <svg fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+        <rect height="14" rx="4" stroke="currentColor" stroke-width="2" width="14" x="5" y="5"/>
+        <circle cx="12" cy="12" r="3.5" stroke="currentColor" stroke-width="2"/>
+        <circle cx="16.5" cy="7.5" fill="currentColor" r="1"/>
+       </svg>
+      </span>
+      <span class="home-social__label" data-i18n-es="Abrir Instagram" data-i18n-en="Open Instagram">
+        Abrir Instagram
+       </span>
+     </a>
+   </div>
+  </div>
  </div>
 </div>
 </main>

--- a/styles/main.css
+++ b/styles/main.css
@@ -138,24 +138,56 @@ body.inicio main {
 }
 
 .home-panel {
-  background:linear-gradient(145deg, rgba(243,232,213,0.94), rgba(255,245,232,0.85));
-  border-radius:28px;
-  padding:clamp(1.5rem, 4vw, 2.25rem);
-  box-shadow:0 24px 60px rgba(33, 22, 15, 0.25);
-  width:min(100%, 360px);
+  background:linear-gradient(155deg, rgba(243,232,213,0.94), rgba(255,247,236,0.85));
+  border-radius:32px;
+  padding:clamp(1.75rem, 4.5vw, 2.75rem);
+  box-shadow:0 28px 65px rgba(33, 22, 15, 0.25);
+  width:min(100%, 420px);
   display:flex;
   flex-direction:column;
   justify-content:center;
+  align-items:flex-start;
+  text-align:left;
+  gap:0.5rem;
   backdrop-filter:blur(10px);
   border:1px solid rgba(91,58,41,0.14);
   margin:0;
+}
+
+.home-panel__eyebrow {
+  margin:0 0 0.5rem;
+  font-size:0.75rem;
+  font-weight:700;
+  letter-spacing:0.32em;
+  text-transform:uppercase;
+  color:var(--gereni-muted);
+}
+
+.home-panel__title {
+  margin:0 0 0.75rem;
+  font-family:'Alegreya', 'Times New Roman', serif;
+  font-size:clamp(1.6rem, 3.6vw, 2.1rem);
+  color:var(--gereni-brown);
+  line-height:1.2;
+}
+
+.home-panel__subtitle {
+  margin:0 0 clamp(1.25rem, 3vw, 1.75rem);
+  color:var(--gereni-muted);
+  font-size:0.95rem;
+  line-height:1.6;
+}
+
+.home-actions[data-variant="primary"] {
+  gap:clamp(1rem, 2.6vw, 1.4rem);
+  margin-bottom:clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .home-actions {
   list-style:none;
   display:flex;
   flex-direction:column;
-  gap:clamp(0.9rem, 2.5vw, 1.3rem);
+  gap:clamp(0.85rem, 2.2vw, 1.2rem);
   padding:0;
   margin:0;
 }
@@ -167,20 +199,21 @@ body.inicio main {
 .home-actions__link {
   flex:1;
   display:flex;
-  align-items:center;
-  justify-content:center;
-  padding:1rem clamp(1.25rem, 4vw, 1.75rem);
-  border-radius:20px;
+  align-items:flex-start;
+  justify-content:flex-start;
+  gap:clamp(0.9rem, 2.4vw, 1.25rem);
+  padding:clamp(1rem, 3vw, 1.3rem) clamp(1.2rem, 4vw, 1.8rem);
+  border-radius:24px;
   font-weight:600;
-  letter-spacing:0.06em;
-  text-transform:uppercase;
+  letter-spacing:0.01em;
+  text-transform:none;
   text-decoration:none;
   color:var(--gereni-brown);
   background:linear-gradient(160deg, rgba(255,255,255,0.92), rgba(248,238,223,0.8));
-  box-shadow:0 16px 38px rgba(91,58,41,0.18);
+  box-shadow:0 18px 40px rgba(91,58,41,0.18);
   position:relative;
   overflow:hidden;
-  transition:transform 0.25s ease, box-shadow 0.25s ease, background 0.3s ease;
+  transition:transform 0.25s ease, box-shadow 0.25s ease, background 0.3s ease, color 0.3s ease;
 }
 
 .home-actions__link::after {
@@ -206,7 +239,7 @@ body.inicio main {
 .home-actions__link--primary {
   background:linear-gradient(140deg, rgba(75,106,61,0.94), rgba(130,161,112,0.85));
   color:#fff;
-  box-shadow:0 20px 40px rgba(75,106,61,0.3);
+  box-shadow:0 24px 44px rgba(75,106,61,0.3);
 }
 
 .home-actions__link--primary::after {
@@ -218,9 +251,225 @@ body.inicio main {
   border:1px solid rgba(91,58,41,0.18);
 }
 
+.home-actions__icon {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  width:clamp(2.75rem, 5.5vw, 3.25rem);
+  height:clamp(2.75rem, 5.5vw, 3.25rem);
+  border-radius:18px;
+  background:rgba(255,255,255,0.18);
+  color:inherit;
+  box-shadow:inset 0 1px 0 rgba(255,255,255,0.4), 0 10px 20px rgba(0,0,0,0.08);
+  flex-shrink:0;
+}
+
+.home-actions__content {
+  display:flex;
+  flex-direction:column;
+  gap:0.35rem;
+  align-items:flex-start;
+}
+
+.home-actions__title {
+  font-size:1.05rem;
+  letter-spacing:0.04em;
+  text-transform:uppercase;
+}
+
+.home-actions__description {
+  font-size:0.9rem;
+  font-weight:500;
+  color:var(--gereni-muted);
+  line-height:1.55;
+}
+
+.home-actions__link--primary .home-actions__description {
+  color:rgba(255,255,255,0.82);
+}
+
+.home-social {
+  display:flex;
+  flex-direction:column;
+  gap:0.85rem;
+  align-items:flex-start;
+}
+
+.home-social__title {
+  margin:0;
+  font-size:0.85rem;
+  letter-spacing:0.18em;
+  text-transform:uppercase;
+  color:var(--gereni-muted);
+}
+
+.home-social__buttons {
+  display:flex;
+  gap:0.75rem;
+  flex-wrap:wrap;
+}
+
+.home-social__link {
+  display:inline-flex;
+  align-items:center;
+  gap:0.6rem;
+  padding:0.65rem 1.1rem;
+  border-radius:999px;
+  text-decoration:none;
+  font-weight:600;
+  letter-spacing:0.02em;
+  background:rgba(255,255,255,0.85);
+  color:var(--gereni-brown);
+  border:1px solid rgba(91,58,41,0.12);
+  box-shadow:0 12px 26px rgba(27,19,13,0.12);
+  transition:transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
+}
+
+.home-social__link:hover,
+.home-social__link:focus-visible {
+  transform:translateY(-2px);
+  box-shadow:0 16px 32px rgba(27,19,13,0.18);
+  background:rgba(255,255,255,0.95);
+  outline:none;
+}
+
 .home-actions__link--social {
-  background:linear-gradient(160deg, rgba(255,255,255,0.9), rgba(237,227,211,0.78));
-  border:1px solid rgba(91,58,41,0.15);
+  text-transform:none;
+}
+
+.home-social__icon {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:2rem;
+  height:2rem;
+  border-radius:50%;
+  background:rgba(91,58,41,0.08);
+  color:var(--gereni-brown);
+}
+
+.home-social__link--facebook {
+  background:linear-gradient(140deg, rgba(59,89,152,0.92), rgba(80,110,180,0.85));
+  color:#fff;
+  border:none;
+}
+
+.home-social__link--facebook .home-social__icon {
+  background:rgba(255,255,255,0.18);
+  color:#fff;
+}
+
+.home-social__link--instagram {
+  background:linear-gradient(135deg, rgba(245,133,41,0.9), rgba(235,68,90,0.92) 55%, rgba(99,84,186,0.95));
+  color:#fff;
+  border:none;
+}
+
+.home-social__link--instagram .home-social__icon {
+  background:rgba(255,255,255,0.24);
+  color:#fff;
+}
+
+html[data-theme="dark"] .home-panel {
+  background:linear-gradient(155deg, rgba(25,24,22,0.92), rgba(37,34,32,0.88));
+  border:1px solid rgba(234,215,192,0.2);
+  box-shadow:0 24px 70px rgba(0,0,0,0.45);
+}
+
+html[data-theme="dark"] .home-panel__title {
+  color:var(--gereni-brown);
+}
+
+html[data-theme="dark"] .home-panel__subtitle,
+html[data-theme="dark"] .home-actions__description,
+html[data-theme="dark"] .home-panel__eyebrow,
+html[data-theme="dark"] .home-social__title {
+  color:rgba(234,215,192,0.75);
+}
+
+html[data-theme="dark"] .home-actions__link {
+  background:linear-gradient(160deg, rgba(33,31,29,0.95), rgba(45,42,39,0.85));
+  color:var(--gereni-brown);
+  border:1px solid rgba(234,215,192,0.12);
+  box-shadow:0 20px 46px rgba(0,0,0,0.4);
+}
+
+html[data-theme="dark"] .home-actions__link--primary {
+  background:linear-gradient(140deg, rgba(111,147,98,0.92), rgba(146,176,135,0.85));
+  box-shadow:0 24px 44px rgba(0,0,0,0.45);
+}
+
+html[data-theme="dark"] .home-actions__icon {
+  background:rgba(234,215,192,0.08);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,0.06), 0 12px 22px rgba(0,0,0,0.28);
+}
+
+html[data-theme="dark"] .home-actions__link--primary .home-actions__description {
+  color:rgba(255,255,255,0.78);
+}
+
+html[data-theme="dark"] .home-social__link {
+  background:rgba(33,31,29,0.85);
+  color:var(--gereni-brown);
+  border:1px solid rgba(234,215,192,0.18);
+  box-shadow:0 16px 38px rgba(0,0,0,0.35);
+}
+
+html[data-theme="dark"] .home-social__link:hover,
+html[data-theme="dark"] .home-social__link:focus-visible {
+  background:rgba(43,39,36,0.95);
+}
+
+html[data-theme="dark"] .home-social__icon {
+  background:rgba(234,215,192,0.08);
+  color:var(--gereni-brown);
+}
+
+html[data-theme="dark"] .home-social__link--facebook,
+html[data-theme="dark"] .home-social__link--instagram {
+  border:none;
+}
+
+@media (max-width: 640px) {
+  .home-panel {
+    width:100%;
+    padding:clamp(1.5rem, 8vw, 2.4rem);
+  }
+
+  .home-actions[data-variant="primary"] .home-actions__link {
+    align-items:center;
+  }
+
+  .home-actions__icon {
+    width:3rem;
+    height:3rem;
+  }
+
+  .home-social__buttons {
+    width:100%;
+  }
+
+  .home-social__link {
+    flex:1 1 calc(50% - 0.6rem);
+    justify-content:center;
+    text-align:center;
+  }
+}
+
+@media (max-width: 440px) {
+  .home-actions[data-variant="primary"] .home-actions__link {
+    flex-direction:column;
+    align-items:flex-start;
+  }
+
+  .home-actions__icon {
+    width:2.75rem;
+    height:2.75rem;
+  }
+
+  .home-social__link {
+    flex:1 1 100%;
+  }
 }
 
 h1,


### PR DESCRIPTION
## Summary
- redesign the home quick actions panel with descriptive copy and icon-enhanced buttons for menu and PDF download
- add a dedicated social follow row with branded styling while keeping localization hooks intact
- extend styling for the refreshed layout across dark mode, hover states, and small-screen breakpoints

## Testing
- npm run test:sync
- npm run test:a11y
- npm run check:all *(fails: missing data/home-highlights.json and external network access when validating social links)*

------
https://chatgpt.com/codex/tasks/task_e_69014b628f688323a5fdcf357c340c93