### PR TITLE
Remove hero intro copy from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,15 +106,6 @@
 <main>
 <div class="home-hero">
  <div class="home-panel" role="navigation" aria-label="Acciones rápidas" data-i18n-attr="aria-label" data-i18n-es="Acciones rápidas" data-i18n-en="Quick actions">
-  <p class="home-panel__eyebrow" data-i18n-es="Planifica tu visita" data-i18n-en="Plan your visit">
-       Planifica tu visita
-      </p>
-  <h2 class="home-panel__title" data-i18n-es="Sabores caseros, ambiente familiar" data-i18n-en="Homestyle flavors, warm hospitality">
-       Sabores caseros, ambiente familiar
-      </h2>
-  <p class="home-panel__subtitle" data-i18n-es="Explora el menú digital o descárgalo para compartirlo al instante." data-i18n-en="Browse the digital menu or download it to share in seconds.">
-       Explora el menú digital o descárgalo para compartirlo al instante.
-      </p>
   <ul class="home-actions" data-variant="primary">
    <li class="home-actions__item">
     <a class="home-actions__link home-actions__link--primary" href="menu.html">


### PR DESCRIPTION
## Summary
- remove the hero eyebrow, heading, and subtitle copy from the homepage quick actions panel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69016a251198832397992ed3926fced0