### PR TITLE
Switch flag badge based on selected language

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
 </script>
 <script defer="" src="scripts/headerControls.js">
 </script>
+<script defer="" src="scripts/flagBadge.js">
+</script>
 <script defer="" src="scripts/pdfLink.js">
 </script>
 <script defer="" src="scripts/swRegister.js">
@@ -56,7 +58,7 @@
 <h1 class="sr-only" data-i18n-es="Gereni Bar y Restaurante" data-i18n-en="Gereni Bar &amp; Restaurant">
     Gereni Bar y Restaurante
    </h1>
-<img alt="Bandera de Costa Rica" class="flag-badge" data-i18n-attr="alt" data-i18n-en="Flag of Costa Rica" data-i18n-es="Bandera de Costa Rica" src="assets/photos/Flag_of_Costa_Rica.svg"/>
+<img alt="Bandera de Costa Rica" class="flag-badge" data-i18n-attr="alt" data-i18n-en="Flag of the United States" data-i18n-es="Bandera de Costa Rica" data-lang-src-en="assets/photos/Flag_of_the_United_States.svg" data-lang-src-es="assets/photos/Flag_of_Costa_Rica.svg" src="assets/photos/Flag_of_Costa_Rica.svg"/>
 <div class="header-controls">
 <div class="control-dropdown" data-controls-dropdown="">
 <button aria-controls="header-preferences" aria-expanded="false" aria-haspopup="true" class="control-dropdown__trigger" data-controls-toggle="" data-i18n-attr="aria-label" data-i18n-en="Open language and style options" data-i18n-es="Abrir opciones de idioma y estilo" type="button">

--- a/scripts/flagBadge.js
+++ b/scripts/flagBadge.js
@@ -1,0 +1,49 @@
+(() => {
+  const SELECTOR = '[data-lang-src-es], [data-lang-src-en]';
+
+  function getPreferredSrc(element, lang) {
+    if (!element || !element.dataset) return null;
+    if (lang === 'en' && element.dataset.langSrcEn) {
+      return element.dataset.langSrcEn;
+    }
+    if (lang === 'es' && element.dataset.langSrcEs) {
+      return element.dataset.langSrcEs;
+    }
+    return element.dataset.langSrcEs || element.dataset.langSrcEn || null;
+  }
+
+  function updateFlagBadge(lang) {
+    document.querySelectorAll(SELECTOR).forEach(element => {
+      const nextSrc = getPreferredSrc(element, lang);
+      if (nextSrc && element.getAttribute('src') !== nextSrc) {
+        element.setAttribute('src', nextSrc);
+      }
+    });
+  }
+
+  function resolveLanguage(event) {
+    if (event && event.detail && typeof event.detail.lang === 'string') {
+      return event.detail.lang;
+    }
+    if (window.GereniLang && typeof window.GereniLang.getCurrent === 'function') {
+      return window.GereniLang.getCurrent();
+    }
+    return document.documentElement.getAttribute('lang') || 'es';
+  }
+
+  function init() {
+    const initialLang = resolveLanguage();
+    updateFlagBadge(initialLang);
+
+    document.addEventListener('gereni:languagechange', event => {
+      const lang = resolveLanguage(event);
+      updateFlagBadge(lang);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- update the home page flag badge with localized alt text and language-specific image sources
- add a client-side helper that swaps the badge image whenever the language changes

## Testing
- npm run check:menu

------
https://chatgpt.com/codex/tasks/task_e_69016ea939548323a83125f55ed3ff8a