### PR TITLE
Add automated promo showcase to home hero

### DIFF
--- a/assets/promos/README.md
+++ b/assets/promos/README.md
@@ -1,0 +1,27 @@
+# Guía de promociones
+
+Las imágenes colocadas en `assets/promos/` se muestran automáticamente en la vitrina de anuncios de la página de inicio. Para mantener una presentación consistente y nítida, utiliza las siguientes recomendaciones.
+
+## Formatos recomendados
+- **JPG/JPEG**: ideal para fotografías o composiciones con muchos degradados.
+- **PNG**: úsalo cuando necesites conservar transparencias o texto muy definido.
+- **WEBP/AVIF**: preferibles cuando dispongas de la exportación, ya que ofrecen mejor compresión.
+- **SVG**: solo para ilustraciones vectoriales sin efectos complejos de rasterizado.
+
+Evita GIF animados u otros formatos que puedan distraer o aumentar el peso de la página.
+
+## Dimensiones y composición
+- Diseña en orientación **vertical** con relación de aspecto entre **3:4 y 4:5** (ej. 1080 × 1440 px).
+- Exporta siempre al menos al doble del ancho mostrado (≥ 900 px) para pantallas de alta densidad.
+- Mantén márgenes seguros de 32 px alrededor de textos o logotipos para que no queden cortados.
+
+## Peso y optimización
+- Procura que cada archivo pese **menos de 450 KB**. Usa herramientas de compresión (TinyPNG, Squoosh, etc.).
+- Asigna nombres descriptivos en minúsculas y con guiones (ej. `2025-03-cocktail-noche.jpg`).
+
+## Flujo de actualización
+1. Coloca los archivos dentro de `assets/promos/` siguiendo las recomendaciones anteriores.
+2. Ejecuta `npm run build:promos` (o cualquier flujo que invoque `npm run build:fallback`) para actualizar el manifiesto.
+3. Sube los cambios junto con el archivo `promos.json` generado automáticamente.
+
+Los anuncios se ordenan por fecha de modificación más reciente, mostrando primero las campañas más nuevas.

--- a/assets/promos/promos.json
+++ b/assets/promos/promos.json
@@ -1,0 +1,9 @@
+{
+  "generatedAt": "2025-10-29T01:59:39.062Z",
+  "items": [
+    {
+      "src": "assets/promos/noche_mascarada.jpg",
+      "updatedAt": "2025-10-29T01:54:00.811Z"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
 </script>
 <script defer="" src="scripts/flagBadge.js">
 </script>
+<script defer="" src="scripts/promoShowcase.js">
+</script>
 <script defer="" src="scripts/pdfLink.js">
 </script>
 <script defer="" src="scripts/swRegister.js">
@@ -107,6 +109,8 @@
 </header>
 <main>
 <div class="home-hero">
+ <div aria-hidden="true" class="home-promos" data-promos-root="" hidden="">
+ </div>
  <div class="home-panel" role="navigation" aria-label="Acciones rápidas" data-i18n-attr="aria-label" data-i18n-es="Acciones rápidas" data-i18n-en="Quick actions">
   <ul class="home-actions" data-variant="primary">
    <li class="home-actions__item">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Menú editable de Gereni Bar y Restaurante, sincronizado desde Markdown hacia web e impresión.",
   "main": "index.js",
   "scripts": {
-    "build:fallback": "node tools/build-static-menu.js",
+    "build:promos": "node tools/generate-promos-manifest.js",
+    "build:fallback": "npm run build:promos && node tools/build-static-menu.js",
     "check:all": "npm run build:fallback && npm run check:prices && npm run check:menu && npm run check:social && npm run test:sync && npm run test:a11y",
     "check:menu": "node tools/check-menu-render.js",
     "check:prices": "node tools/validate-prices.js",

--- a/scripts/promoShowcase.js
+++ b/scripts/promoShowcase.js
@@ -1,0 +1,82 @@
+(function() {
+  'use strict';
+
+  const promosRoot = document.querySelector('[data-promos-root]');
+  if (!promosRoot) {
+    return;
+  }
+
+  const MANIFEST_URL = 'assets/promos/promos.json';
+
+  function resolveItems(manifest) {
+    if (!manifest) return [];
+    if (Array.isArray(manifest.items)) return manifest.items;
+    if (Array.isArray(manifest)) return manifest;
+    return [];
+  }
+
+  function normalizeSource(entry) {
+    if (entry && typeof entry === 'object' && typeof entry.src === 'string') {
+      return entry.src.trim();
+    }
+
+    if (typeof entry === 'string') {
+      return entry.trim();
+    }
+
+    return '';
+  }
+
+  function isAllowedSource(src) {
+    if (!src) return false;
+    return src.startsWith('assets/promos/');
+  }
+
+  function createPromoElement(src, index) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'home-promos__item';
+
+    const img = document.createElement('img');
+    img.className = 'home-promos__image';
+    img.src = src;
+    img.alt = '';
+    img.decoding = 'async';
+    img.setAttribute('aria-hidden', 'true');
+    if (index > 0) {
+      img.loading = 'lazy';
+    }
+
+    wrapper.appendChild(img);
+    return wrapper;
+  }
+
+  fetch(MANIFEST_URL, { cache: 'no-store' })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Failed to load promo manifest');
+      }
+
+      return response.json();
+    })
+    .then(manifest => {
+      const urls = resolveItems(manifest)
+        .map(normalizeSource)
+        .filter(isAllowedSource);
+
+      if (urls.length === 0) {
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      urls.forEach((src, index) => {
+        fragment.appendChild(createPromoElement(src, index));
+      });
+
+      promosRoot.appendChild(fragment);
+      promosRoot.removeAttribute('hidden');
+      promosRoot.setAttribute('data-promos-count', String(urls.length));
+    })
+    .catch(() => {
+      // Si no se encuentra el manifiesto o es inválido, mantenemos la sección oculta.
+    });
+})();

--- a/styles/main.css
+++ b/styles/main.css
@@ -125,16 +125,65 @@ body.inicio main {
   position:relative;
   z-index:1;
   display:flex;
-  justify-content:center;
-  align-items:flex-start;
+  flex-direction:column;
+  justify-content:flex-start;
+  align-items:center;
+  gap:clamp(1.5rem, 5vw, 2.75rem);
   padding-inline:clamp(0.5rem, 3vw, 1.5rem);
   box-sizing:border-box;
 }
 
 @media (min-width: 900px) {
   .home-hero {
+    flex-direction:row;
+    align-items:stretch;
     justify-content:flex-end;
   }
+}
+
+.home-promos {
+  width:100%;
+  max-width:min(520px, 100%);
+  margin:0;
+  padding:clamp(1.15rem, 3vw, 1.75rem);
+  display:flex;
+  flex-direction:column;
+  gap:clamp(0.85rem, 2vw, 1.2rem);
+  border-radius:28px;
+  background:rgba(255,255,255,0.12);
+  border:1px solid rgba(255,255,255,0.28);
+  box-shadow:0 32px 70px rgba(32, 24, 18, 0.3);
+  backdrop-filter:blur(18px);
+  -webkit-backdrop-filter:blur(18px);
+  overflow:hidden;
+}
+
+@media (min-width: 900px) {
+  .home-promos {
+    margin-right:auto;
+  }
+}
+
+.home-promos__item {
+  border-radius:22px;
+  overflow:hidden;
+  background:rgba(0,0,0,0.18);
+  border:1px solid rgba(255,255,255,0.18);
+  box-shadow:0 18px 46px rgba(0,0,0,0.22);
+}
+
+.home-promos__image {
+  display:block;
+  width:100%;
+  height:auto;
+  aspect-ratio:3 / 4;
+  object-fit:cover;
+  transition:transform 0.4s ease;
+}
+
+.home-promos__image:hover,
+.home-promos__image:focus-visible {
+  transform:scale(1.01);
 }
 
 .home-panel {
@@ -1037,6 +1086,18 @@ body[data-theme="dark"].inicio .home-panel {
   background:linear-gradient(145deg, rgba(30,28,26,0.94), rgba(44,41,38,0.82));
   box-shadow:0 28px 60px rgba(0,0,0,0.5);
   border:1px solid rgba(234,215,192,0.22);
+}
+
+body[data-theme="dark"].inicio .home-promos {
+  background:rgba(24,22,20,0.82);
+  border:1px solid rgba(234,215,192,0.24);
+  box-shadow:0 34px 74px rgba(0,0,0,0.55);
+}
+
+body[data-theme="dark"].inicio .home-promos__item {
+  background:rgba(0,0,0,0.32);
+  border-color:rgba(234,215,192,0.22);
+  box-shadow:0 20px 48px rgba(0,0,0,0.5);
 }
 
 body[data-theme="dark"].inicio .home-actions__link {

--- a/tools/generate-promos-manifest.js
+++ b/tools/generate-promos-manifest.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+const fs = require('fs/promises');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const PROMOS_DIR = path.join(ROOT, 'assets', 'promos');
+const OUTPUT_PATH = path.join(PROMOS_DIR, 'promos.json');
+const ALLOWED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.avif', '.svg']);
+
+async function ensureDirectory() {
+  try {
+    await fs.access(PROMOS_DIR);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function readPromoFiles() {
+  if (!(await ensureDirectory())) {
+    return [];
+  }
+
+  const entries = await fs.readdir(PROMOS_DIR, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const ext = path.extname(entry.name).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.has(ext)) {
+      continue;
+    }
+
+    const filePath = path.join(PROMOS_DIR, entry.name);
+    const stats = await fs.stat(filePath);
+
+    files.push({
+      name: entry.name,
+      mtime: stats.mtimeMs,
+      updatedAt: stats.mtime.toISOString()
+    });
+  }
+
+  files.sort((a, b) => {
+    if (b.mtime !== a.mtime) {
+      return b.mtime - a.mtime;
+    }
+
+    return a.name.localeCompare(b.name, 'en');
+  });
+
+  return files.map(file => ({
+    src: `assets/promos/${file.name}`,
+    updatedAt: file.updatedAt
+  }));
+}
+
+async function writeManifest(items) {
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    items
+  };
+
+  const content = `${JSON.stringify(payload, null, 2)}\n`;
+  await fs.writeFile(OUTPUT_PATH, content, 'utf8');
+}
+
+async function main() {
+  try {
+    const items = await readPromoFiles();
+    await writeManifest(items);
+    if (process.env.CI) {
+      console.log(`Generated promo manifest with ${items.length} item(s).`);
+    }
+  } catch (error) {
+    console.error('No fue posible generar el manifiesto de promociones.');
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a promo showcase container on the home hero and populate it automatically from the promos manifest
- style the glassy promo window for light and dark themes
- generate the promos manifest via tooling and document asset preparation guidelines

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_690173ab85ec83239fc3d3037f3e96e9