### PR TITLE
Remove seasonal highlight from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,30 +155,6 @@
      </a>
    </li>
   </ul>
-  <article class="home-highlight" data-seasonal-effect="halloween">
-   <div class="home-highlight__media">
-    <img alt="Ilustración promocional de la Noche de Mascarada" class="home-highlight__image" data-i18n-attr="alt" data-i18n-en="Promotional illustration for Masquerade Night" data-i18n-es="Ilustración promocional de la Noche de Mascarada" loading="lazy" src="assets/promos/noche_mascarada.jpg"/>
-   </div>
-   <div class="home-highlight__content">
-    <p class="home-highlight__eyebrow" data-i18n-en="Seasonal special" data-i18n-es="Especial de temporada">
-      Especial de temporada
-     </p>
-    <h3 class="home-highlight__title" data-i18n-en="Masquerade Night" data-i18n-es="Noche de Mascarada">
-      Noche de Mascarada
-     </h3>
-    <p class="home-highlight__description" data-i18n-en="Celebrate Halloween with themed cocktails, costume prizes, and live music all night long." data-i18n-es="Celebra Halloween con cócteles temáticos, premios a los mejores disfraces y música en vivo toda la noche.">
-      Celebra Halloween con cócteles temáticos, premios a los mejores disfraces y música en vivo toda la noche.
-     </p>
-    <a class="home-highlight__cta" href="https://sandgraal.github.io/gereni-menu/menu.html#especiales" rel="noopener" target="_blank">
-     <span data-i18n-en="Reserve your table" data-i18n-es="Reserva tu mesa">
-        Reserva tu mesa
-       </span>
-    </a>
-   </div>
-   <span class="sr-only" data-i18n-en="Activates a decorative Halloween surprise across the home page." data-i18n-es="Activa una sorpresa decorativa de Halloween en la página de inicio.">
-      Activa una sorpresa decorativa de Halloween en la página de inicio.
-     </span>
-  </article>
   <div class="home-social">
    <p class="home-social__title" data-i18n-es="Conéctate con nosotros" data-i18n-en="Connect with us">
         Conéctate con nosotros


### PR DESCRIPTION
## Summary
- remove the Halloween highlight card from the home page quick actions panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69019120fe448323bcb9516bc9afe931