### PR TITLE
Add icon-based preference toggles for theme and language

### DIFF
--- a/assets/promos/promos.json
+++ b/assets/promos/promos.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2025-10-29T01:59:39.062Z",
+  "generatedAt": "2025-10-29T05:39:45.024Z",
   "items": [
     {
       "src": "assets/promos/noche_mascarada.jpg",
-      "updatedAt": "2025-10-29T01:54:00.811Z"
+      "updatedAt": "2025-10-29T05:35:46.561Z"
     }
   ]
 }

--- a/index.html
+++ b/index.html
@@ -20,8 +20,6 @@
 </script>
 <script defer="" src="scripts/theme.js">
 </script>
-<script defer="" src="scripts/headerControls.js">
-</script>
 <script defer="" src="scripts/seasonalEffects.js">
 </script>
 <script defer="" src="scripts/flagBadge.js">
@@ -63,48 +61,31 @@
     Gereni Bar y Restaurante
    </h1>
 <img alt="Bandera de Costa Rica" class="flag-badge" data-i18n-attr="alt" data-i18n-en="Flag of the United States" data-i18n-es="Bandera de Costa Rica" data-lang-src-en="assets/photos/Flag_of_the_United_States.svg" data-lang-src-es="assets/photos/Flag_of_Costa_Rica.svg" src="assets/photos/Flag_of_Costa_Rica.svg"/>
-<div class="header-controls">
-<div class="control-dropdown" data-controls-dropdown="">
-<button aria-controls="header-preferences" aria-expanded="false" aria-haspopup="true" class="control-dropdown__trigger" data-controls-toggle="" data-i18n-attr="aria-label" data-i18n-en="Open language and style options" data-i18n-es="Abrir opciones de idioma y estilo" type="button">
-      <span data-i18n-en="Language &amp; style" data-i18n-es="Idioma y estilo">
-        Idioma y estilo
-       </span>
-      <span aria-hidden="true" class="control-dropdown__icon">
-        &#9662;
-       </span>
-     </button>
-<div class="control-dropdown__panel" data-controls-menu="" hidden="" id="header-preferences">
-<div class="control-section">
-<p class="control-section__title" data-i18n-en="Visual style" data-i18n-es="Estilo visual">
-          Estilo visual
-         </p>
-<div aria-label="Cambiar estilo visual" class="theme-toggle" data-i18n-attr="aria-label" data-i18n-en="Switch visual theme" data-i18n-es="Cambiar estilo visual" data-theme-toggle="" role="group">
-<button aria-label="Usar el tema oscuro" aria-pressed="true" data-i18n-attr="aria-label" data-i18n-en="Use the dark theme" data-i18n-es="Usar el tema oscuro" data-theme-option="dark" type="button">
-            <span data-i18n-en="Dark" data-i18n-es="Oscuro">
-              Oscuro
-             </span>
-           </button>
-<button aria-label="Usar el tema claro" aria-pressed="false" data-i18n-attr="aria-label" data-i18n-en="Use the light theme" data-i18n-es="Usar el tema claro" data-theme-option="light" type="button">
-            <span data-i18n-en="Light" data-i18n-es="Claro">
-              Claro
-             </span>
-           </button>
-         </div>
-       </div>
-<div class="control-section">
-<p class="control-section__title" data-i18n-en="Language" data-i18n-es="Idioma">
-          Idioma
-         </p>
-<div aria-label="Seleccionar idioma" class="language-toggle" data-i18n-attr="aria-label" data-i18n-en="Choose language" data-i18n-es="Seleccionar idioma" data-lang-toggle="" role="group">
-<button aria-label="Cambiar a español" aria-pressed="true" data-i18n-attr="aria-label" data-i18n-en="Switch to Spanish" data-i18n-es="Cambiar a español" data-lang-option="es" type="button">
-            ES
-           </button>
-<button aria-label="Cambiar a inglés" aria-pressed="false" data-i18n-attr="aria-label" data-i18n-en="Switch to English" data-i18n-es="Cambiar a inglés" data-lang-option="en" type="button">
-            EN
-           </button>
-         </div>
-       </div>
-     </div>
+   <div class="header-controls preference-controls">
+    <button aria-label="Cambiar a tema claro" aria-pressed="true" class="preference-button preference-button--theme" data-theme-label-dark-en="Dark" data-theme-label-dark-es="Oscuro" data-theme-label-light-en="Light" data-theme-label-light-es="Claro" data-theme-next-dark-en="Switch to light theme" data-theme-next-dark-es="Cambiar a tema claro" data-theme-next-light-en="Switch to dark theme" data-theme-next-light-es="Cambiar a tema oscuro" data-theme-toggle-button="" data-theme-state="dark" data-theme-next="light" type="button">
+     <span aria-hidden="true" class="preference-button__icon">
+      <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+       <path class="yin-dark" d="M16 3a13 13 0 0 0 0 26c1.9 0 3.7-.43 5.3-1.27a9 9 0 1 1 0-23.46A12.96 12.96 0 0 0 16 3Z" fill="currentColor"></path>
+       <path class="yin-light" d="M21.3 4.27c-.86-.18-1.75-.27-2.65-.27a9 9 0 0 0 0 18c.9 0 1.79-.09 2.65-.27A6 6 0 0 1 21.3 4.27Z" fill="currentColor"></path>
+      </svg>
+     </span>
+     <span class="preference-button__text">
+      <span class="preference-button__hint" data-i18n-en="Style" data-i18n-es="Estilo">Estilo</span>
+      <span class="preference-button__value" data-theme-label="">Oscuro</span>
+     </span>
+    </button>
+    <button aria-label="Cambiar a inglés" aria-pressed="true" class="preference-button preference-button--language" data-lang-cycle-button="" data-lang-label-en="English" data-lang-label-es="Español" data-lang-next-en="Switch to Spanish" data-lang-next-es="Cambiar a inglés" data-lang-next="en" data-lang-state="es" type="button">
+     <span aria-hidden="true" class="preference-button__icon">
+      <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+       <path d="M6 9a5 5 0 0 1 5-5h10a5 5 0 0 1 5 5v8a5 5 0 0 1-5 5h-2.38l-4.42 5.21A.75.75 0 0 1 13 26.74V22H11a5 5 0 0 1-5-5Z" fill="currentColor"></path>
+       <path d="M11.75 11h8.5M11.75 15h5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path>
+      </svg>
+     </span>
+     <span class="preference-button__text">
+      <span class="preference-button__hint" data-i18n-en="Language" data-i18n-es="Idioma">Idioma</span>
+      <span class="preference-button__value" data-lang-label="">Español</span>
+     </span>
+    </button>
    </div>
  </div>
 <img alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-en="Gereni Bar &amp; Restaurant logo" data-i18n-es="Logo de Gereni Bar y Restaurante" src="assets/logo-gereni-bar-restaurant.png"/>

--- a/menu.html
+++ b/menu.html
@@ -1,25 +1,1654 @@
- <div class="menu-header__controls preference-controls">
-  <button aria-label="Cambiar a tema claro" aria-pressed="true" class="preference-button preference-button--theme" data-theme-label-dark-en="Dark" data-theme-label-dark-es="Oscuro" data-theme-label-light-en="Light" data-theme-label-light-es="Claro" data-theme-next-dark-en="Switch to light theme" data-theme-next-dark-es="Cambiar a tema claro" data-theme-next-light-en="Switch to dark theme" data-theme-next-light-es="Cambiar a tema oscuro" data-theme-toggle-button="" data-theme-state="dark" data-theme-next="light" type="button">
-   <span aria-hidden="true" class="preference-button__icon">
-    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-     <path class="yin-dark" d="M16 3a13 13 0 0 0 0 26c1.9 0 3.7-.43 5.3-1.27a9 9 0 1 1 0-23.46A12.96 12.96 0 0 0 16 3Z" fill="currentColor"></path>
-     <path class="yin-light" d="M21.3 4.27c-.86-.18-1.75-.27-2.65-.27a9 9 0 0 0 0 18c.9 0 1.79-.09 2.65-.27A6 6 0 0 1 21.3 4.27Z" fill="currentColor"></path>
-    </svg>
-   </span>
-   <span class="preference-button__text">
-    <span class="preference-button__hint" data-i18n-en="Style" data-i18n-es="Estilo">Estilo</span>
-    <span class="preference-button__value" data-theme-label="">Oscuro</span>
-   </span>
-  </button>
-  <button aria-label="Cambiar a inglés" aria-pressed="true" class="preference-button preference-button--language" data-lang-cycle-button="" data-lang-label-en="English" data-lang-label-es="Español" data-lang-next-en="Switch to Spanish" data-lang-next-es="Cambiar a inglés" data-lang-next="en" data-lang-state="es" type="button">
-   <span aria-hidden="true" class="preference-button__icon">
-    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-     <path d="M6 9a5 5 0 0 1 5-5h10a5 5 0 0 1 5 5v8a5 5 0 0 1-5 5h-2.38l-4.42 5.21A.75.75 0 0 1 13 26.74V22H11a5 5 0 0 1-5-5Z" fill="currentColor"></path>
-     <path d="M11.75 11h8.5M11.75 15h5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path>
-    </svg>
-   </span>
-   <span class="preference-button__text">
-    <span class="preference-button__hint" data-i18n-en="Language" data-i18n-es="Idioma">Idioma</span>
-    <span class="preference-button__value" data-lang-label="">Español</span>
-   </span>
-  </button>
+<!DOCTYPE html>
+<html lang="es" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Menú completo de Gereni Bar y Restaurante en Atirro, Cartago. Platillos costarricenses, mariscos y especialidades de la casa." />
+  <meta property="og:title" content="Menú - Gereni Bar y Restaurante" />
+  <meta property="og:description" content="Menú completo de Gereni Bar y Restaurante en Atirro, Cartago. Platillos costarricenses, mariscos y especialidades de la casa." />
+  <meta property="og:image" content="https://sandgraal.github.io/gereni-menu/assets/logo-gereni-bar-restaurant.png" />
+  <meta property="og:url" content="https://sandgraal.github.io/gereni-menu/menu.html" />
+  <title data-i18n-es="Menú - Gereni Bar y Restaurante" data-i18n-en="Menu - Gereni Bar &amp; Restaurant">Menú - Gereni Bar y Restaurante</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;600;700&amp;family=Source+Sans+3:wght@400;600;700&amp;display=swap" />
+  <link rel="stylesheet" href="styles/main.css" />
+  <link rel="stylesheet" href="styles/print.css" media="print" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <script defer src="scripts/i18n.js"></script>
+  <script defer src="scripts/theme.js"></script>
+  <script defer src="scripts/loadMenu.js"></script>
+  <script defer src="scripts/pdfLink.js"></script>
+  <script defer src="scripts/swRegister.js"></script>
+  <script type="application/ld+json" id="menu-schema">
+{
+  "@context": "https://schema.org",
+  "@type": "Menu",
+  "@id": "https://sandgraal.github.io/gereni-menu/menu.html#menu",
+  "name": "Menú principal",
+  "inLanguage": "es-CR",
+  "url": "https://sandgraal.github.io/gereni-menu/menu.html",
+  "isPartOf": {
+    "@id": "https://sandgraal.github.io/gereni-menu/#restaurant"
+  },
+  "hasMenuSection": [
+    {
+      "@type": "MenuSection",
+      "name": "Gustitos",
+      "hasMenuItem": [
+        {
+          "@type": "MenuItem",
+          "name": "Fajitas Mixtas",
+          "alternateName": "Mixed Fajitas",
+          "description": "Acompañadas con papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4800",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Fajitas de Pollo o Carne",
+          "alternateName": "Chicken or Beef Fajitas",
+          "description": "Acompañadas con papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Nuggets de Pollo",
+          "alternateName": "Chicken Nuggets",
+          "description": "Acompañadas con papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3700",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Dedos de Pescado",
+          "alternateName": "Fish Sticks",
+          "description": "Acompañados de papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Ceviche de Pescado",
+          "alternateName": "Fish Ceviche",
+          "description": "Preparado fresco del día.",
+          "disambiguatingDescription": "Prepared fresh each day.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Ceviche Mixto",
+          "alternateName": "Mixed Ceviche",
+          "description": "Selección de mariscos del día.",
+          "disambiguatingDescription": "Chef's daily seafood selection.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3700",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Sopa Azteca",
+          "alternateName": "Aztec Soup",
+          "description": "Caldo tradicional con tortilla y queso.",
+          "disambiguatingDescription": "Traditional broth with tortilla and cheese.",
+          "image": "assets/photos/gustitos-sopa-azteca.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "4000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Sopa Negra",
+          "alternateName": "Black Bean Soup",
+          "description": "Acompañada de arroz.",
+          "disambiguatingDescription": "Served with rice.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Carne en Salsa",
+          "alternateName": "Beef in Sauce",
+          "description": "Acompañada de arroz.",
+          "disambiguatingDescription": "Served with rice.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Garbanzos / Frijoles Blancos / Pozol",
+          "alternateName": "Chickpeas / White Beans / Pozol",
+          "description": "Porción casera del día.",
+          "disambiguatingDescription": "Homestyle portion of the day.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Canelones",
+          "alternateName": "Cannelloni",
+          "description": "2 unidades bañadas en salsa de tomate.",
+          "disambiguatingDescription": "Two pieces covered in tomato sauce.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Yuca Frita",
+          "alternateName": "Fried Yuca",
+          "description": "Bastones crujientes con aderezo de la casa.",
+          "disambiguatingDescription": "Crispy sticks with our house dressing.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        }
+      ],
+      "alternateName": "Starters"
+    },
+    {
+      "@type": "MenuSection",
+      "name": "Con arroz",
+      "hasMenuItem": [
+        {
+          "@type": "MenuItem",
+          "name": "Casados",
+          "alternateName": "Casados Plate",
+          "description": "Con arroz, frijoles, picadillo, ensalada y una carne.",
+          "disambiguatingDescription": "Rice, beans, picadillo, salad, and your choice of protein.",
+          "image": "assets/photos/con-arroz-casados.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "3390",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Casado Criollo",
+          "alternateName": "Criollo Casado",
+          "description": "Arroz, frijoles, picadillo, ensalada, huevo, queso y refresco.",
+          "disambiguatingDescription": "Rice, beans, picadillo, salad, egg, cheese, and a drink.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Arroz de la Casa",
+          "alternateName": "House Special Rice",
+          "description": "Cerdo, pollo, camarones, chorizo, ensalada y papas.",
+          "disambiguatingDescription": "Pork, chicken, shrimp, chorizo, salad, and fries.",
+          "image": "assets/photos/con-arroz-arroz-de-la-casa.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "4750",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Arroz con Pollo",
+          "alternateName": "Chicken Rice",
+          "description": "Acompañado de papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3995",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Arroz con Camarones",
+          "alternateName": "Shrimp Rice",
+          "description": "Acompañado de papas y ensalada.",
+          "disambiguatingDescription": "Served with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4520",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        }
+      ],
+      "alternateName": "With Rice"
+    },
+    {
+      "@type": "MenuSection",
+      "name": "Antojitos",
+      "hasMenuItem": [
+        {
+          "@type": "MenuItem",
+          "name": "Nachos",
+          "description": "Carne o pollo.",
+          "disambiguatingDescription": "Beef or chicken.",
+          "image": "assets/photos/antojitos-nachos.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "3500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Chalupa",
+          "description": "Carne o pollo.",
+          "disambiguatingDescription": "Beef or chicken.",
+          "image": "assets/photos/antojitos-chalupa.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "2000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Chicharrones",
+          "alternateName": "Crispy Pork Bites",
+          "description": "Porción crujiente de la casa.",
+          "disambiguatingDescription": "House crispy pork portion.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Hamburguesa Sencilla",
+          "alternateName": "Classic Burger",
+          "description": "Acompañada con papas.",
+          "disambiguatingDescription": "Served with fries.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Hamburguesa Gereni",
+          "alternateName": "Gereni Burger",
+          "description": "Torta de huevo, tocineta, carne, cebolla caramelizada, jamón y queso.",
+          "disambiguatingDescription": "Egg patty, bacon, beef, caramelized onion, ham, and cheese.",
+          "image": "assets/photos/antojitos-hamburguesa-gereni.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "4200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Patacones",
+          "description": "Con frijoles molidos.",
+          "disambiguatingDescription": "With refried beans.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2260",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Papas Fiesta",
+          "alternateName": "Fiesta Fries",
+          "description": "Papas con topping especial de la casa.",
+          "disambiguatingDescription": "Fries with our house topping.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4100",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Papas Fritas",
+          "alternateName": "French Fries",
+          "description": "Orden individual de papas.",
+          "disambiguatingDescription": "Individual order of fries.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Plato Surtido",
+          "alternateName": "Sampler Platter",
+          "description": "Chicharrones, chorizo, pollo, salchichón, verdura y pico de gallo.",
+          "disambiguatingDescription": "Pork bites, chorizo, chicken, sausage, veggies, and pico de gallo.",
+          "offers": {
+            "@type": "Offer",
+            "price": "8100",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Brochetas de Camarón",
+          "alternateName": "Shrimp Skewers",
+          "description": "Con patacones y pico de gallo.",
+          "disambiguatingDescription": "Served with patacones and pico de gallo.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4700",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Alitas de Pollo (4 piezas)",
+          "alternateName": "Chicken Wings (4 pieces)",
+          "description": "Salsa a elegir, acompañadas de papas.",
+          "disambiguatingDescription": "Your choice of sauce, served with fries.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Alitas de Pollo (6 piezas)",
+          "alternateName": "Chicken Wings (6 pieces)",
+          "description": "Salsa a elegir, acompañadas de papas.",
+          "disambiguatingDescription": "Your choice of sauce, served with fries.",
+          "offers": {
+            "@type": "Offer",
+            "price": "7000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Alitas de Pollo (8 piezas)",
+          "alternateName": "Chicken Wings (8 pieces)",
+          "description": "Salsa a elegir, acompañadas de papas.",
+          "disambiguatingDescription": "Your choice of sauce, served with fries.",
+          "offers": {
+            "@type": "Offer",
+            "price": "9000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Quesadillas a la Plancha",
+          "alternateName": "Griddled Quesadillas",
+          "description": "Tortillas rellenas de queso y vegetales salteados.",
+          "disambiguatingDescription": "Tortillas stuffed with cheese and sautéed veggies.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        }
+      ],
+      "alternateName": "Cravings"
+    },
+    {
+      "@type": "MenuSection",
+      "name": "Especialidades",
+      "hasMenuItem": [
+        {
+          "@type": "MenuItem",
+          "name": "Costillas BBQ",
+          "alternateName": "BBQ Ribs",
+          "description": "De cerdo en salsa BBQ con arroz y ensalada.",
+          "disambiguatingDescription": "Pork ribs in BBQ sauce with rice and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5850",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Filet de Pargo",
+          "alternateName": "Red Snapper Fillet",
+          "description": "Preparado al gusto con papas y ensalada.",
+          "disambiguatingDescription": "Cooked to taste with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Filet de Tilapia",
+          "alternateName": "Tilapia Fillet",
+          "description": "Al gusto, con papas y ensalada.",
+          "disambiguatingDescription": "Cooked to taste with fries and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5085",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Pollo Agridulce",
+          "alternateName": "Sweet and Sour Chicken",
+          "description": "Trocitos de pollo en salsa agridulce con arroz y ensalada.",
+          "disambiguatingDescription": "Chicken bites in sweet and sour sauce with rice and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Filet de Pollo",
+          "alternateName": "Chicken Fillet",
+          "description": "Al gusto, con papas y ensalada.",
+          "disambiguatingDescription": "Cooked to taste with fries and salad.",
+          "image": "assets/photos/especialidades-filet-de-pollo.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "5200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Pastas (Alfredo, Bechamel o Tomate)",
+          "alternateName": "Pasta (Alfredo, Béchamel or Tomato)",
+          "description": "Servidas con pan de ajo.",
+          "disambiguatingDescription": "Served with garlic bread.",
+          "offers": {
+            "@type": "Offer",
+            "price": "3500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Filete de Pollo en Salsa Bechamel",
+          "alternateName": "Chicken Fillet in Béchamel Sauce",
+          "description": "Con arroz y ensalada.",
+          "disambiguatingDescription": "With rice and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "4520",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Filet Miñon",
+          "alternateName": "Filet Mignon",
+          "description": "Lomito recubierto con tocineta en salsa de vino.",
+          "disambiguatingDescription": "Tenderloin wrapped in bacon with wine sauce.",
+          "offers": {
+            "@type": "Offer",
+            "price": "7150",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Medallones de Lomito",
+          "alternateName": "Tenderloin Medallions",
+          "description": "En salsa con papa asada y ensalada.",
+          "disambiguatingDescription": "In sauce with baked potato and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "7500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Tomahawk / Ribeye / New York",
+          "description": "Acompañado de papa asada y ensalada.",
+          "disambiguatingDescription": "Served with baked potato and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "13000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Lengua en Salsa",
+          "alternateName": "Beef Tongue in Sauce",
+          "description": "Medallones en salsa de tomate con arroz y ensalada.",
+          "disambiguatingDescription": "Slices in tomato sauce with rice and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5650",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Gordon Bleu",
+          "alternateName": "Cordon Bleu",
+          "description": "Pechuga de pollo con jamón, queso mozarela, puré y ensalada.",
+          "disambiguatingDescription": "Chicken breast with ham, mozzarella, mash, and salad.",
+          "offers": {
+            "@type": "Offer",
+            "price": "5650",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        }
+      ],
+      "alternateName": "Specialties"
+    },
+    {
+      "@type": "MenuSection",
+      "name": "Para el café",
+      "hasMenuItem": [
+        {
+          "@type": "MenuItem",
+          "name": "Club Sandwich",
+          "description": "Capas de pan, pollo y vegetales.",
+          "disambiguatingDescription": "Layers of bread, chicken, and vegetables.",
+          "image": "assets/photos/para-el-cafe-club-sandwich.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "4200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Sandwich",
+          "description": "Carne, pollo o jamón con queso.",
+          "disambiguatingDescription": "Beef, chicken, or ham with cheese.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2300",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Tortilla de Queso",
+          "alternateName": "Cheese Tortilla",
+          "description": "Con natilla.",
+          "disambiguatingDescription": "Served with sour cream.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2500",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Tortilla con Torta de Huevo",
+          "alternateName": "Tortilla with Egg Patty",
+          "description": "Preparada a la plancha.",
+          "disambiguatingDescription": "Griddled to order.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Prensadas",
+          "alternateName": "Fried Cheese Tortillas",
+          "description": "Tortillas fritas con queso.",
+          "disambiguatingDescription": "Fried tortillas with cheese.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Empanadas",
+          "description": "Rellenas al gusto.",
+          "disambiguatingDescription": "Filled to your liking.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1800",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Arepas con Natilla o Mermelada",
+          "alternateName": "Arepas with Cream or Jam",
+          "description": "Dulce casero para acompañar el café.",
+          "disambiguatingDescription": "Homemade sweet treat for your coffee.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1700",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Queque de Zanahoria",
+          "alternateName": "Carrot Cake",
+          "description": "Rebanada casera con glaseado de queso crema.",
+          "disambiguatingDescription": "House slice with cream cheese frosting.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2400",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        }
+      ],
+      "alternateName": "Coffee Time"
+    },
+    {
+      "@type": "MenuSection",
+      "name": "Bebidas",
+      "hasMenuItem": [
+        {
+          "@type": "MenuItem",
+          "name": "Café",
+          "alternateName": "Coffee",
+          "description": "Taza de café chorreado.",
+          "disambiguatingDescription": "Pour-over coffee cup.",
+          "image": "assets/photos/bebidas-cafe.png",
+          "offers": {
+            "@type": "Offer",
+            "price": "1200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Agua Dulce",
+          "description": "Bebida tradicional de tapa de dulce.",
+          "disambiguatingDescription": "Traditional sugarcane drink.",
+          "offers": {
+            "@type": "Offer",
+            "price": "900",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Chocolate",
+          "alternateName": "Hot Chocolate",
+          "description": "Chocolate caliente.",
+          "disambiguatingDescription": "Hot chocolate.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1200",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Té Negro",
+          "alternateName": "Black Tea",
+          "description": "Infusión caliente.",
+          "disambiguatingDescription": "Hot infusion.",
+          "offers": {
+            "@type": "Offer",
+            "price": "800",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Batidos en Leche",
+          "alternateName": "Milk Shakes",
+          "description": "Sabores a elección.",
+          "disambiguatingDescription": "Choice of flavors.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2300",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Frescos Naturales",
+          "alternateName": "Fresh Juices",
+          "description": "Jugos naturales del día.",
+          "disambiguatingDescription": "Daily natural juices.",
+          "offers": {
+            "@type": "Offer",
+            "price": "2000",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        },
+        {
+          "@type": "MenuItem",
+          "name": "Limonada con Hierbabuena",
+          "alternateName": "Mint Lemonade",
+          "description": "Refrescante mezcla con hierbabuena fresca.",
+          "disambiguatingDescription": "Refreshing blend with fresh mint.",
+          "offers": {
+            "@type": "Offer",
+            "price": "1800",
+            "priceCurrency": "CRC",
+            "availability": "https://schema.org/InStock"
+          }
+        }
+      ],
+      "alternateName": "Drinks"
+    }
+  ],
+  "dateModified": "2025-10-28T04:44:16.706Z"
+}
+</script>
+</head>
+<body class="menu-page" data-theme="dark">
+  <header>
+    <h1 class="sr-only" data-i18n-es="Menú - Gereni Bar y Restaurante" data-i18n-en="Menu - Gereni Bar &amp; Restaurant">
+      Menú - Gereni Bar y Restaurante
+    </h1>
+    <img src="assets/photos/Flag_of_Costa_Rica.svg" alt="Bandera de Costa Rica" class="flag-badge" data-i18n-attr="alt" data-i18n-es="Bandera de Costa Rica" data-i18n-en="Flag of the United States" data-lang-src-es="assets/photos/Flag_of_Costa_Rica.svg" data-lang-src-en="assets/photos/Flag_of_the_United_States.svg" />
+    <div class="menu-header__controls preference-controls">
+      <button aria-label="Cambiar a tema claro" aria-pressed="true" class="preference-button preference-button--theme" data-theme-label-dark-en="Dark" data-theme-label-dark-es="Oscuro" data-theme-label-light-en="Light" data-theme-label-light-es="Claro" data-theme-next-dark-en="Switch to light theme" data-theme-next-dark-es="Cambiar a tema claro" data-theme-next-light-en="Switch to dark theme" data-theme-next-light-es="Cambiar a tema oscuro" data-theme-toggle-button="" data-theme-state="dark" data-theme-next="light" type="button">
+        <span aria-hidden="true" class="preference-button__icon">
+          <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+            <path class="yin-dark" d="M16 3a13 13 0 0 0 0 26c1.9 0 3.7-.43 5.3-1.27a9 9 0 1 1 0-23.46A12.96 12.96 0 0 0 16 3Z" fill="currentColor"></path>
+            <path class="yin-light" d="M21.3 4.27c-.86-.18-1.75-.27-2.65-.27a9 9 0 0 0 0 18c.9 0 1.79-.09 2.65-.27A6 6 0 0 1 21.3 4.27Z" fill="currentColor"></path>
+          </svg>
+        </span>
+        <span class="preference-button__text">
+          <span class="preference-button__hint" data-i18n-en="Style" data-i18n-es="Estilo">Estilo</span>
+          <span class="preference-button__value" data-theme-label="">Oscuro</span>
+        </span>
+      </button>
+      <button aria-label="Cambiar a inglés" aria-pressed="true" class="preference-button preference-button--language" data-lang-cycle-button="" data-lang-label-en="English" data-lang-label-es="Español" data-lang-next-en="Switch to Spanish" data-lang-next-es="Cambiar a inglés" data-lang-next="en" data-lang-state="es" type="button">
+        <span aria-hidden="true" class="preference-button__icon">
+          <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+            <path d="M6 9a5 5 0 0 1 5-5h10a5 5 0 0 1 5 5v8a5 5 0 0 1-5 5h-2.38l-4.42 5.21A.75.75 0 0 1 13 26.74V22H11a5 5 0 0 1-5-5Z" fill="currentColor"></path>
+            <path d="M11.75 11h8.5M11.75 15h5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+        </span>
+        <span class="preference-button__text">
+          <span class="preference-button__hint" data-i18n-en="Language" data-i18n-es="Idioma">Idioma</span>
+          <span class="preference-button__value" data-lang-label="">Español</span>
+        </span>
+      </button>
+    </div>
+    <img src="assets/logo-gereni-bar-restaurant.png" alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-es="Logo de Gereni Bar y Restaurante" data-i18n-en="Gereni Bar &amp; Restaurant logo" />
+  </header>
+  <main>
+    <div class="menu-container" id="menu-container">
+      <div class="menu-controls">
+        <input type="search" id="menu-search-input" class="menu-search" placeholder="Buscar platillos..." data-i18n-attr="placeholder" data-i18n-es="Buscar platillos..." data-i18n-en="Search menu items..." />
+        <button type="button" class="menu-search__clear" id="menu-search-clear" aria-label="Limpiar búsqueda" data-i18n-attr="aria-label" data-i18n-es="Limpiar búsqueda" data-i18n-en="Clear search" hidden>
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+      </div>
+      <p class="menu-updated" id="menu-updated" data-menu-updated-label>
+        <!-- MENU_NOTE_START -->Actualizado el 28 de octubre de 2025<!-- MENU_NOTE_END -->
+      </p>
+      <div class="menu-content" data-menu-root>
+                <!-- FALLBACK_MENU_START -->
+  <div class="menu-column menu-column--left">
+    <section class="menu-section">
+      <h2 class="menu-section__title">
+        <span class="menu-section__title-primary">Gustitos</span>
+        <span class="menu-section__title-secondary">Starters</span>
+      </h2>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Fajitas Mixtas</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.800</span>
+          </div>
+          <span class="dish-name-alt">Mixed Fajitas</span>
+          <p class="dish-description">Acompañadas con papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Fajitas de Pollo o Carne</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.500</span>
+          </div>
+          <span class="dish-name-alt">Chicken or Beef Fajitas</span>
+          <p class="dish-description">Acompañadas con papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Nuggets de Pollo</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.700</span>
+          </div>
+          <span class="dish-name-alt">Chicken Nuggets</span>
+          <p class="dish-description">Acompañadas con papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Dedos de Pescado</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.500</span>
+          </div>
+          <span class="dish-name-alt">Fish Sticks</span>
+          <p class="dish-description">Acompañados de papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Ceviche de Pescado</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.000</span>
+          </div>
+          <span class="dish-name-alt">Fish Ceviche</span>
+          <p class="dish-description">Preparado fresco del día.</p>
+          <p class="dish-description dish-description--alt">Prepared fresh each day.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Ceviche Mixto</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.700</span>
+          </div>
+          <span class="dish-name-alt">Mixed Ceviche</span>
+          <p class="dish-description">Selección de mariscos del día.</p>
+          <p class="dish-description dish-description--alt">Chef&#39;s daily seafood selection.</p>
+        </div>
+      </article>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/gustitos-sopa-azteca.png" alt="Sopa Azteca" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Sopa Azteca</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.000</span>
+          </div>
+          <span class="dish-name-alt">Aztec Soup</span>
+          <p class="dish-description">Caldo tradicional con tortilla y queso.</p>
+          <p class="dish-description dish-description--alt">Traditional broth with tortilla and cheese.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Sopa Negra</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.000</span>
+          </div>
+          <span class="dish-name-alt">Black Bean Soup</span>
+          <p class="dish-description">Acompañada de arroz.</p>
+          <p class="dish-description dish-description--alt">Served with rice.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Carne en Salsa</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.500</span>
+          </div>
+          <span class="dish-name-alt">Beef in Sauce</span>
+          <p class="dish-description">Acompañada de arroz.</p>
+          <p class="dish-description dish-description--alt">Served with rice.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Garbanzos / Frijoles Blancos / Pozol</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.000</span>
+          </div>
+          <span class="dish-name-alt">Chickpeas / White Beans / Pozol</span>
+          <p class="dish-description">Porción casera del día.</p>
+          <p class="dish-description dish-description--alt">Homestyle portion of the day.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Canelones</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.200</span>
+          </div>
+          <span class="dish-name-alt">Cannelloni</span>
+          <p class="dish-description">2 unidades bañadas en salsa de tomate.</p>
+          <p class="dish-description dish-description--alt">Two pieces covered in tomato sauce.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Yuca Frita</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.200</span>
+          </div>
+          <span class="dish-name-alt">Fried Yuca</span>
+          <p class="dish-description">Bastones crujientes con aderezo de la casa.</p>
+          <p class="dish-description dish-description--alt">Crispy sticks with our house dressing.</p>
+        </div>
+      </article>
+    </section>
+    <section class="menu-section">
+      <h2 class="menu-section__title">
+        <span class="menu-section__title-primary">Con arroz</span>
+        <span class="menu-section__title-secondary">With Rice</span>
+      </h2>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/con-arroz-casados.png" alt="Casados" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Casados</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.390</span>
+          </div>
+          <span class="dish-name-alt">Casados Plate</span>
+          <p class="dish-description">Con arroz, frijoles, picadillo, ensalada y una carne.</p>
+          <p class="dish-description dish-description--alt">Rice, beans, picadillo, salad, and your choice of protein.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Casado Criollo</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.500</span>
+          </div>
+          <span class="dish-name-alt">Criollo Casado</span>
+          <p class="dish-description">Arroz, frijoles, picadillo, ensalada, huevo, queso y refresco.</p>
+          <p class="dish-description dish-description--alt">Rice, beans, picadillo, salad, egg, cheese, and a drink.</p>
+        </div>
+      </article>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/con-arroz-arroz-de-la-casa.png" alt="Arroz de la Casa" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Arroz de la Casa</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.750</span>
+          </div>
+          <span class="dish-name-alt">House Special Rice</span>
+          <p class="dish-description">Cerdo, pollo, camarones, chorizo, ensalada y papas.</p>
+          <p class="dish-description dish-description--alt">Pork, chicken, shrimp, chorizo, salad, and fries.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Arroz con Pollo</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.995</span>
+          </div>
+          <span class="dish-name-alt">Chicken Rice</span>
+          <p class="dish-description">Acompañado de papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Arroz con Camarones</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.520</span>
+          </div>
+          <span class="dish-name-alt">Shrimp Rice</span>
+          <p class="dish-description">Acompañado de papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with fries and salad.</p>
+        </div>
+      </article>
+    </section>
+    <section class="menu-section">
+      <h2 class="menu-section__title">
+        <span class="menu-section__title-primary">Antojitos</span>
+        <span class="menu-section__title-secondary">Cravings</span>
+      </h2>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/antojitos-nachos.png" alt="Nachos" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Nachos</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.500</span>
+          </div>
+          <p class="dish-description">Carne o pollo.</p>
+          <p class="dish-description dish-description--alt">Beef or chicken.</p>
+        </div>
+      </article>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/antojitos-chalupa.png" alt="Chalupa" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Chalupa</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.000</span>
+          </div>
+          <p class="dish-description">Carne o pollo.</p>
+          <p class="dish-description dish-description--alt">Beef or chicken.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Chicharrones</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.000</span>
+          </div>
+          <span class="dish-name-alt">Crispy Pork Bites</span>
+          <p class="dish-description">Porción crujiente de la casa.</p>
+          <p class="dish-description dish-description--alt">House crispy pork portion.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Hamburguesa Sencilla</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.500</span>
+          </div>
+          <span class="dish-name-alt">Classic Burger</span>
+          <p class="dish-description">Acompañada con papas.</p>
+          <p class="dish-description dish-description--alt">Served with fries.</p>
+        </div>
+      </article>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/antojitos-hamburguesa-gereni.png" alt="Hamburguesa Gereni" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Hamburguesa Gereni</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.200</span>
+          </div>
+          <span class="dish-name-alt">Gereni Burger</span>
+          <p class="dish-description">Torta de huevo, tocineta, carne, cebolla caramelizada, jamón y queso.</p>
+          <p class="dish-description dish-description--alt">Egg patty, bacon, beef, caramelized onion, ham, and cheese.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Patacones</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.260</span>
+          </div>
+          <p class="dish-description">Con frijoles molidos.</p>
+          <p class="dish-description dish-description--alt">With refried beans.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Papas Fiesta</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.100</span>
+          </div>
+          <span class="dish-name-alt">Fiesta Fries</span>
+          <p class="dish-description">Papas con topping especial de la casa.</p>
+          <p class="dish-description dish-description--alt">Fries with our house topping.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Papas Fritas</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.500</span>
+          </div>
+          <span class="dish-name-alt">French Fries</span>
+          <p class="dish-description">Orden individual de papas.</p>
+          <p class="dish-description dish-description--alt">Individual order of fries.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Plato Surtido</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡8.100</span>
+          </div>
+          <span class="dish-name-alt">Sampler Platter</span>
+          <p class="dish-description">Chicharrones, chorizo, pollo, salchichón, verdura y pico de gallo.</p>
+          <p class="dish-description dish-description--alt">Pork bites, chorizo, chicken, sausage, veggies, and pico de gallo.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Brochetas de Camarón</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.700</span>
+          </div>
+          <span class="dish-name-alt">Shrimp Skewers</span>
+          <p class="dish-description">Con patacones y pico de gallo.</p>
+          <p class="dish-description dish-description--alt">Served with patacones and pico de gallo.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Alitas de Pollo (4 piezas)</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.000</span>
+          </div>
+          <span class="dish-name-alt">Chicken Wings (4 pieces)</span>
+          <p class="dish-description">Salsa a elegir, acompañadas de papas.</p>
+          <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Alitas de Pollo (6 piezas)</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡7.000</span>
+          </div>
+          <span class="dish-name-alt">Chicken Wings (6 pieces)</span>
+          <p class="dish-description">Salsa a elegir, acompañadas de papas.</p>
+          <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Alitas de Pollo (8 piezas)</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡9.000</span>
+          </div>
+          <span class="dish-name-alt">Chicken Wings (8 pieces)</span>
+          <p class="dish-description">Salsa a elegir, acompañadas de papas.</p>
+          <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Quesadillas a la Plancha</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.200</span>
+          </div>
+          <span class="dish-name-alt">Griddled Quesadillas</span>
+          <p class="dish-description">Tortillas rellenas de queso y vegetales salteados.</p>
+          <p class="dish-description dish-description--alt">Tortillas stuffed with cheese and sautéed veggies.</p>
+        </div>
+      </article>
+    </section>
+  </div>
+  <div class="menu-column menu-column--right">
+    <section class="menu-section">
+      <h2 class="menu-section__title">
+        <span class="menu-section__title-primary">Especialidades</span>
+        <span class="menu-section__title-secondary">Specialties</span>
+      </h2>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Costillas BBQ</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.850</span>
+          </div>
+          <span class="dish-name-alt">BBQ Ribs</span>
+          <p class="dish-description">De cerdo en salsa BBQ con arroz y ensalada.</p>
+          <p class="dish-description dish-description--alt">Pork ribs in BBQ sauce with rice and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Filet de Pargo</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.200</span>
+          </div>
+          <span class="dish-name-alt">Red Snapper Fillet</span>
+          <p class="dish-description">Preparado al gusto con papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Cooked to taste with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Filet de Tilapia</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.085</span>
+          </div>
+          <span class="dish-name-alt">Tilapia Fillet</span>
+          <p class="dish-description">Al gusto, con papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Cooked to taste with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Pollo Agridulce</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.000</span>
+          </div>
+          <span class="dish-name-alt">Sweet and Sour Chicken</span>
+          <p class="dish-description">Trocitos de pollo en salsa agridulce con arroz y ensalada.</p>
+          <p class="dish-description dish-description--alt">Chicken bites in sweet and sour sauce with rice and salad.</p>
+        </div>
+      </article>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/especialidades-filet-de-pollo.png" alt="Filet de Pollo" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Filet de Pollo</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.200</span>
+          </div>
+          <span class="dish-name-alt">Chicken Fillet</span>
+          <p class="dish-description">Al gusto, con papas y ensalada.</p>
+          <p class="dish-description dish-description--alt">Cooked to taste with fries and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Pastas (Alfredo, Bechamel o Tomate)</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡3.500</span>
+          </div>
+          <span class="dish-name-alt">Pasta (Alfredo, Béchamel or Tomato)</span>
+          <p class="dish-description">Servidas con pan de ajo.</p>
+          <p class="dish-description dish-description--alt">Served with garlic bread.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Filete de Pollo en Salsa Bechamel</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.520</span>
+          </div>
+          <span class="dish-name-alt">Chicken Fillet in Béchamel Sauce</span>
+          <p class="dish-description">Con arroz y ensalada.</p>
+          <p class="dish-description dish-description--alt">With rice and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Filet Miñon</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡7.150</span>
+          </div>
+          <span class="dish-name-alt">Filet Mignon</span>
+          <p class="dish-description">Lomito recubierto con tocineta en salsa de vino.</p>
+          <p class="dish-description dish-description--alt">Tenderloin wrapped in bacon with wine sauce.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Medallones de Lomito</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡7.500</span>
+          </div>
+          <span class="dish-name-alt">Tenderloin Medallions</span>
+          <p class="dish-description">En salsa con papa asada y ensalada.</p>
+          <p class="dish-description dish-description--alt">In sauce with baked potato and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Tomahawk / Ribeye / New York</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡13.000</span>
+          </div>
+          <p class="dish-description">Acompañado de papa asada y ensalada.</p>
+          <p class="dish-description dish-description--alt">Served with baked potato and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Lengua en Salsa</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.650</span>
+          </div>
+          <span class="dish-name-alt">Beef Tongue in Sauce</span>
+          <p class="dish-description">Medallones en salsa de tomate con arroz y ensalada.</p>
+          <p class="dish-description dish-description--alt">Slices in tomato sauce with rice and salad.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Gordon Bleu</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡5.650</span>
+          </div>
+          <span class="dish-name-alt">Cordon Bleu</span>
+          <p class="dish-description">Pechuga de pollo con jamón, queso mozarela, puré y ensalada.</p>
+          <p class="dish-description dish-description--alt">Chicken breast with ham, mozzarella, mash, and salad.</p>
+        </div>
+      </article>
+    </section>
+    <section class="menu-section">
+      <h2 class="menu-section__title">
+        <span class="menu-section__title-primary">Para el café</span>
+        <span class="menu-section__title-secondary">Coffee Time</span>
+      </h2>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/para-el-cafe-club-sandwich.png" alt="Club Sandwich" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Club Sandwich</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡4.200</span>
+          </div>
+          <p class="dish-description">Capas de pan, pollo y vegetales.</p>
+          <p class="dish-description dish-description--alt">Layers of bread, chicken, and vegetables.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Sandwich</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.300</span>
+          </div>
+          <p class="dish-description">Carne, pollo o jamón con queso.</p>
+          <p class="dish-description dish-description--alt">Beef, chicken, or ham with cheese.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Tortilla de Queso</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.500</span>
+          </div>
+          <span class="dish-name-alt">Cheese Tortilla</span>
+          <p class="dish-description">Con natilla.</p>
+          <p class="dish-description dish-description--alt">Served with sour cream.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Tortilla con Torta de Huevo</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.200</span>
+          </div>
+          <span class="dish-name-alt">Tortilla with Egg Patty</span>
+          <p class="dish-description">Preparada a la plancha.</p>
+          <p class="dish-description dish-description--alt">Griddled to order.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Prensadas</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.200</span>
+          </div>
+          <span class="dish-name-alt">Fried Cheese Tortillas</span>
+          <p class="dish-description">Tortillas fritas con queso.</p>
+          <p class="dish-description dish-description--alt">Fried tortillas with cheese.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Empanadas</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.800</span>
+          </div>
+          <p class="dish-description">Rellenas al gusto.</p>
+          <p class="dish-description dish-description--alt">Filled to your liking.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Arepas con Natilla o Mermelada</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.700</span>
+          </div>
+          <span class="dish-name-alt">Arepas with Cream or Jam</span>
+          <p class="dish-description">Dulce casero para acompañar el café.</p>
+          <p class="dish-description dish-description--alt">Homemade sweet treat for your coffee.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Queque de Zanahoria</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.400</span>
+          </div>
+          <span class="dish-name-alt">Carrot Cake</span>
+          <p class="dish-description">Rebanada casera con glaseado de queso crema.</p>
+          <p class="dish-description dish-description--alt">House slice with cream cheese frosting.</p>
+        </div>
+      </article>
+    </section>
+    <section class="menu-section">
+      <h2 class="menu-section__title">
+        <span class="menu-section__title-primary">Bebidas</span>
+        <span class="menu-section__title-secondary">Drinks</span>
+      </h2>
+      <article class="dish dish--with-image">
+        <figure class="dish-media">
+          <img src="assets/photos/bebidas-cafe.png" alt="Café" loading="lazy"/>
+        </figure>
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Café</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.200</span>
+          </div>
+          <span class="dish-name-alt">Coffee</span>
+          <p class="dish-description">Taza de café chorreado.</p>
+          <p class="dish-description dish-description--alt">Pour-over coffee cup.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Agua Dulce</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡900</span>
+          </div>
+          <p class="dish-description">Bebida tradicional de tapa de dulce.</p>
+          <p class="dish-description dish-description--alt">Traditional sugarcane drink.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Chocolate</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.200</span>
+          </div>
+          <span class="dish-name-alt">Hot Chocolate</span>
+          <p class="dish-description">Chocolate caliente.</p>
+          <p class="dish-description dish-description--alt">Hot chocolate.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Té Negro</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡800</span>
+          </div>
+          <span class="dish-name-alt">Black Tea</span>
+          <p class="dish-description">Infusión caliente.</p>
+          <p class="dish-description dish-description--alt">Hot infusion.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Batidos en Leche</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.300</span>
+          </div>
+          <span class="dish-name-alt">Milk Shakes</span>
+          <p class="dish-description">Sabores a elección.</p>
+          <p class="dish-description dish-description--alt">Choice of flavors.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Frescos Naturales</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡2.000</span>
+          </div>
+          <span class="dish-name-alt">Fresh Juices</span>
+          <p class="dish-description">Jugos naturales del día.</p>
+          <p class="dish-description dish-description--alt">Daily natural juices.</p>
+        </div>
+      </article>
+      <article class="dish">
+        <div class="dish-content">
+          <div class="dish-header">
+            <span class="dish-name">Limonada con Hierbabuena</span>
+            <span class="dish-leader" aria-hidden="true"></span>
+            <span class="dish-price">₡1.800</span>
+          </div>
+          <span class="dish-name-alt">Mint Lemonade</span>
+          <p class="dish-description">Refrescante mezcla con hierbabuena fresca.</p>
+          <p class="dish-description dish-description--alt">Refreshing blend with fresh mint.</p>
+        </div>
+      </article>
+    </section>
+  </div>
+        <!-- FALLBACK_MENU_END -->
+      </div>
+      <div class="menu-empty-state" id="menu-empty" data-menu-empty hidden>
+        <p data-i18n-es="No se encontraron platillos disponibles en este momento." data-i18n-en="No menu items are available right now.">
+          No se encontraron platillos disponibles en este momento.
+        </p>
+      </div>
+    </div>
+  </main>
+  <footer>
+    <p data-i18n-es="© 2025 Gereni Bar y Restaurante. Todos los derechos reservados." data-i18n-en="© 2025 Gereni Bar &amp; Restaurant. All rights reserved.">
+      © 2025 Gereni Bar y Restaurante. Todos los derechos reservados.
+    </p>
+  </footer>
+</body>
+</html>

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -4,6 +4,8 @@
   const VALID_LANGS = new Set(['es', 'en']);
   const subscribers = new Set();
   let currentLang = DEFAULT_LANG;
+  let langCycleButton = null;
+  let langCycleLabel = null;
 
   function sanitizeLanguage(lang) {
     if (typeof lang !== 'string') return DEFAULT_LANG;
@@ -62,6 +64,28 @@
     });
   }
 
+  function updateLangCycleButton(lang) {
+    if (!langCycleButton) return;
+    const dataset = langCycleButton.dataset;
+    const labelKey = lang === 'en' ? 'langLabelEn' : 'langLabelEs';
+    const nextLang = lang === 'en' ? 'es' : 'en';
+    if (langCycleLabel) {
+      const labelValue = dataset[labelKey] || langCycleLabel.textContent;
+      langCycleLabel.textContent = labelValue;
+    }
+    const nextKey = lang === 'en' ? 'langNextEn' : 'langNextEs';
+    const nextLabel = dataset[nextKey];
+    langCycleButton.dataset.langState = lang;
+    langCycleButton.setAttribute('data-lang-state', lang);
+    langCycleButton.dataset.langNext = nextLang;
+    langCycleButton.setAttribute('data-lang-next', nextLang);
+    langCycleButton.setAttribute('aria-pressed', lang === 'es' ? 'true' : 'false');
+    if (nextLabel) {
+      langCycleButton.setAttribute('aria-label', nextLabel);
+      langCycleButton.title = nextLabel;
+    }
+  }
+
   function dispatchLanguageChange(lang) {
     const detail = { lang };
     subscribers.forEach(fn => {
@@ -82,6 +106,7 @@
     document.documentElement.setAttribute('lang', currentLang === 'en' ? 'en' : 'es');
     applyTranslations(currentLang);
     updateToggleState(currentLang);
+    updateLangCycleButton(currentLang);
     dispatchLanguageChange(currentLang);
   }
 
@@ -92,12 +117,27 @@
     setLanguage(lang);
   }
 
+  function handleCycleButtonClick(event) {
+    if (!langCycleButton) return;
+    if (event) {
+      event.preventDefault();
+    }
+    const nextLang = langCycleButton.getAttribute('data-lang-next') || (currentLang === 'en' ? 'es' : 'en');
+    setLanguage(nextLang);
+  }
+
   currentLang = readStoredLanguage();
 
   function init() {
     document.documentElement.setAttribute('lang', currentLang === 'en' ? 'en' : 'es');
     applyTranslations(currentLang);
     updateToggleState(currentLang);
+    langCycleButton = document.querySelector('[data-lang-cycle-button]');
+    langCycleLabel = langCycleButton ? langCycleButton.querySelector('[data-lang-label]') : null;
+    if (langCycleButton) {
+      langCycleButton.addEventListener('click', handleCycleButtonClick);
+      updateLangCycleButton(currentLang);
+    }
     document.addEventListener('click', handleToggleClick);
     dispatchLanguageChange(currentLang);
   }

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -6,6 +6,8 @@
   let hasStoredPreference = false;
   let systemPreferenceWatcherAttached = false;
   let currentTheme = FALLBACK_THEME;
+  let themeToggleButton = null;
+  let themeToggleLabel = null;
 
   function sanitizeTheme(theme) {
     if (typeof theme !== 'string') return FALLBACK_THEME;
@@ -73,6 +75,51 @@
     });
   }
 
+  function getCurrentLanguage() {
+    try {
+      if (window.GereniLang && typeof window.GereniLang.getCurrent === 'function') {
+        return window.GereniLang.getCurrent();
+      }
+    } catch (err) {
+      console.warn('No se pudo determinar el idioma actual:', err);
+    }
+    return 'es';
+  }
+
+  function updateThemeToggleButton(theme) {
+    if (!themeToggleButton) return;
+
+    const lang = getCurrentLanguage();
+    const langSuffix = lang === 'en' ? 'En' : 'Es';
+    const stateKey = theme === 'light' ? 'Light' : 'Dark';
+    const nextTheme = theme === 'dark' ? 'light' : 'dark';
+
+    themeToggleButton.dataset.themeState = theme;
+    themeToggleButton.setAttribute('data-theme-state', theme);
+    themeToggleButton.dataset.themeNext = nextTheme;
+    themeToggleButton.setAttribute('data-theme-next', nextTheme);
+    themeToggleButton.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+
+    if (themeToggleLabel) {
+      const labelKey = `themeLabel${stateKey}${langSuffix}`;
+      const labelValue = themeToggleButton.dataset[labelKey] || themeToggleLabel.textContent;
+      themeToggleLabel.textContent = labelValue;
+    }
+
+    const nextKey = theme === 'dark' ? `themeNextDark${langSuffix}` : `themeNextLight${langSuffix}`;
+    const nextLabel = themeToggleButton.dataset[nextKey];
+    if (nextLabel) {
+      themeToggleButton.setAttribute('aria-label', nextLabel);
+      themeToggleButton.title = nextLabel;
+    }
+  }
+
+  function handleThemeButtonClick(event) {
+    event.preventDefault();
+    const nextTheme = themeToggleButton?.getAttribute('data-theme-next') || (currentTheme === 'dark' ? 'light' : 'dark');
+    setTheme(nextTheme);
+  }
+
   function handleSystemPreferenceChange() {
     if (hasStoredPreference) return;
     const systemTheme = getSystemTheme();
@@ -109,6 +156,7 @@
     currentTheme = normalized;
     applyTheme(currentTheme);
     updateToggleState(currentTheme);
+    updateThemeToggleButton(currentTheme);
     if (persist) {
       hasStoredPreference = true;
       writeStoredTheme(currentTheme);
@@ -128,6 +176,15 @@
   function init() {
     updateToggleState(currentTheme);
     document.addEventListener('click', handleToggleClick);
+    themeToggleButton = document.querySelector('[data-theme-toggle-button]');
+    themeToggleLabel = themeToggleButton ? themeToggleButton.querySelector('[data-theme-label]') : null;
+    if (themeToggleButton) {
+      themeToggleButton.addEventListener('click', handleThemeButtonClick);
+      updateThemeToggleButton(currentTheme);
+    }
+    document.addEventListener('gereni:languagechange', () => {
+      updateThemeToggleButton(currentTheme);
+    });
     notifySubscribers(currentTheme);
   }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -696,124 +696,187 @@ body.inicio header {
   position:absolute;
   top:1rem;
   right:1.5rem;
-  display:flex;
-  flex-direction:column;
-  gap:0.5rem;
-  align-items:flex-end;
   z-index:3;
 }
 
-.control-dropdown {
-  position:relative;
+.preference-controls {
   display:flex;
-  flex-direction:column;
-  align-items:flex-end;
+  gap:0.65rem;
+  align-items:stretch;
 }
 
-.control-dropdown__trigger {
+.preference-button {
   display:flex;
   align-items:center;
-  gap:0.45rem;
-  padding:0.55rem 0.9rem;
-  border:none;
+  gap:0.55rem;
+  padding:0.55rem 0.9rem 0.55rem 0.65rem;
   border-radius:999px;
-  background-color:rgba(255,255,255,0.85);
+  border:1px solid rgba(91,58,41,0.16);
+  background:rgba(255,255,255,0.92);
   color:var(--gereni-brown);
+  font-size:0.82rem;
   font-weight:600;
-  font-size:0.85rem;
+  line-height:1.1;
   cursor:pointer;
-  box-shadow:0 6px 18px rgba(27,19,13,0.12);
+  box-shadow:0 10px 24px rgba(27,19,13,0.14);
   backdrop-filter:blur(8px);
-  transition:background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition:transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
 }
 
-.control-dropdown__trigger:hover,
-.control-dropdown__trigger:focus-visible {
-  background-color:rgba(75,106,61,0.15);
-  color:var(--gereni-brown);
+.preference-button:hover,
+.preference-button:focus-visible {
+  transform:translateY(-2px);
+  box-shadow:0 18px 32px rgba(27,19,13,0.22);
   outline:none;
 }
 
-.control-dropdown__trigger span:first-child {
-  display:inline-flex;
+.preference-button:focus-visible {
+  border-color:var(--gereni-green);
+  box-shadow:0 18px 32px rgba(75,106,61,0.28);
+}
+
+.preference-button__icon {
+  display:flex;
   align-items:center;
+  justify-content:center;
+  width:2.5rem;
+  height:2.5rem;
+  border-radius:50%;
+  background:radial-gradient(circle at 30% 30%, rgba(255,255,255,0.95), rgba(255,255,255,0.55));
+  color:var(--gereni-green);
+  transition:transform 0.3s ease, background 0.3s ease, color 0.3s ease;
 }
 
-.control-dropdown.is-open .control-dropdown__trigger {
-  background-color:var(--gereni-green);
-  color:#fff;
+.preference-button__icon svg {
+  width:1.45rem;
+  height:1.45rem;
 }
 
-.control-dropdown.is-open .control-dropdown__trigger:hover,
-.control-dropdown.is-open .control-dropdown__trigger:focus-visible {
-  background-color:var(--gereni-brown);
-}
-
-.control-dropdown__icon {
-  font-size:0.75rem;
-  line-height:1;
-  transition:transform 0.2s ease;
-}
-
-.control-dropdown.is-open .control-dropdown__icon {
-  transform:rotate(180deg);
-}
-
-.control-dropdown__panel {
-  position:absolute;
-  top:50%;
-  right:calc(100% + 0.75rem);
-  transform:translateY(-50%) scale(0.96);
+.preference-button__text {
   display:flex;
   flex-direction:column;
-  gap:1rem;
-  width:17rem;
-  max-width:calc(100vw - 2rem);
-  padding:1rem;
-  border-radius:1rem;
-  background-color:rgba(255,255,255,0.95);
-  box-shadow:0 20px 40px rgba(27,19,13,0.16);
-  backdrop-filter:blur(12px);
-  z-index:4;
-  transition:transform 0.24s ease, opacity 0.24s ease;
-  opacity:0;
-  pointer-events:none;
+  align-items:flex-start;
+  gap:0.2rem;
 }
 
-@media (max-width: 640px) {
-  .control-dropdown__panel {
-    top:calc(100% + 0.5rem);
-    right:0;
-    transform:none;
-  }
-
-  .control-dropdown.is-open .control-dropdown__panel {
-    transform:none;
-  }
-}
-
-.control-dropdown.is-open .control-dropdown__panel {
-  opacity:1;
-  pointer-events:auto;
-  transform:translateY(-50%) scale(1);
-}
-
-.control-dropdown__panel[hidden] {
-  display:none !important;
-}
-
-.control-section {
-  display:flex;
-  flex-direction:column;
-  gap:0.5rem;
-}
-
-.control-section__title {
-  margin:0;
-  font-size:0.75rem;
-  letter-spacing:0.08em;
+.preference-button__hint {
+  font-size:0.65rem;
+  letter-spacing:0.12em;
   text-transform:uppercase;
   color:var(--gereni-muted);
+}
+
+.preference-button__value {
+  font-size:0.9rem;
+  color:var(--gereni-brown);
+  transition:color 0.25s ease;
+}
+
+.preference-button--theme[data-theme-state="light"] .preference-button__icon {
+  transform:rotate(180deg);
+  color:var(--gereni-brown);
+  background:radial-gradient(circle at 30% 30%, rgba(255,248,234,0.95), rgba(255,214,162,0.55));
+}
+
+.preference-button--theme .yin-light {
+  opacity:0.35;
+  fill:rgba(255,255,255,0.85);
+  transition:opacity 0.3s ease, fill 0.3s ease;
+}
+
+.preference-button--theme[data-theme-state="light"] .yin-light {
+  opacity:0.85;
+  fill:rgba(91,58,41,0.85);
+}
+
+.preference-button--theme[data-theme-state="light"] .preference-button__value {
+  color:var(--gereni-green);
+}
+
+.preference-button--language .preference-button__icon {
+  color:var(--gereni-brown);
+  background:radial-gradient(circle at 70% 30%, rgba(255,248,234,0.96), rgba(195,221,184,0.55));
+}
+
+.preference-button--language[data-lang-state="en"] .preference-button__icon {
+  color:var(--gereni-green);
+  transform:translateY(-1px);
+}
+
+.preference-button--language[data-lang-state="en"] .preference-button__value {
+  color:var(--gereni-green);
+}
+
+body[data-theme="dark"] .header-controls {
+  right:1.25rem;
+}
+
+body[data-theme="dark"] .preference-button {
+  background:rgba(33,27,23,0.88);
+  border-color:rgba(234,215,192,0.12);
+  color:var(--gereni-text);
+  box-shadow:0 16px 32px rgba(0,0,0,0.45);
+}
+
+body[data-theme="dark"] .preference-button__hint {
+  color:rgba(234,215,192,0.68);
+}
+
+body[data-theme="dark"] .preference-button__value {
+  color:var(--gereni-text);
+}
+
+body[data-theme="dark"] .preference-button__icon {
+  background:radial-gradient(circle at 30% 30%, rgba(91,58,41,0.45), rgba(33,27,23,0.9));
+}
+
+body[data-theme="dark"] .preference-button--theme .yin-light {
+  fill:rgba(234,215,192,0.82);
+}
+
+body[data-theme="dark"] .preference-button--theme[data-theme-state="light"] .yin-light {
+  fill:rgba(33,27,23,0.92);
+}
+
+body[data-theme="dark"] .preference-button--language[data-lang-state="en"] .preference-button__icon {
+  background:radial-gradient(circle at 70% 30%, rgba(91,58,41,0.52), rgba(33,27,23,0.9));
+}
+
+body[data-theme="dark"] .preference-button:hover,
+body[data-theme="dark"] .preference-button:focus-visible {
+  background:rgba(44,35,29,0.95);
+}
+
+.menu-header__controls {
+  position:absolute;
+  top:1rem;
+  right:1rem;
+  z-index:3;
+}
+
+.menu-header__controls .preference-button {
+  box-shadow:0 14px 32px rgba(91,58,41,0.2);
+}
+
+body[data-theme="dark"] .menu-header__controls .preference-button {
+  box-shadow:0 20px 34px rgba(0,0,0,0.48);
+}
+
+@media (max-width: 720px) {
+  .preference-controls {
+    flex-direction:column;
+    align-items:flex-end;
+  }
+
+  .header-controls {
+    right:1rem;
+    top:0.75rem;
+  }
+
+  .menu-header__controls {
+    right:0.75rem;
+    top:0.75rem;
+  }
 }
 
 .menu-header::before,
@@ -1105,108 +1168,10 @@ footer {
   width:100%;
 }
 
-.theme-toggle,
-.language-toggle {
-  display:flex;
-  gap:0.35rem;
-  padding:0.35rem;
-  border-radius:999px;
-  background-color:rgba(255,255,255,0.85);
-  box-shadow:0 6px 18px rgba(27,19,13,0.12);
-  backdrop-filter:blur(8px);
-}
-
-.theme-toggle button,
-.language-toggle button {
-  border:none;
-  background:transparent;
-  color:var(--gereni-muted);
-  font-weight:600;
-  font-size:0.85rem;
-  padding:0.35rem 0.75rem;
-  border-radius:999px;
-  cursor:pointer;
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:0.25rem;
-  transition:background-color 0.2s ease, color 0.2s ease;
-}
-
-.control-dropdown__panel .theme-toggle,
-.control-dropdown__panel .language-toggle {
-  width:100%;
-  justify-content:space-between;
-  background-color:rgba(255,255,255,0.72);
-  box-shadow:none;
-}
-
-.theme-toggle button:hover,
-.theme-toggle button:focus-visible,
-.language-toggle button:hover,
-.language-toggle button:focus-visible {
-  background-color:rgba(75,106,61,0.15);
-  color:var(--gereni-brown);
-  outline:none;
-}
-
-.theme-toggle button.active,
-.language-toggle button.active {
-  background-color:var(--gereni-green);
-  color:#fff;
-}
-
-.theme-toggle button.active:hover,
-.theme-toggle button.active:focus-visible,
-.language-toggle button.active:hover,
-.language-toggle button.active:focus-visible {
-  background-color:var(--gereni-brown);
-}
-
 /* Dark theme overrides */
 body[data-theme="dark"] {
   background-color:var(--gereni-cream);
   color:var(--gereni-text);
-}
-
-body[data-theme="dark"] .control-dropdown__trigger {
-  background-color:rgba(25,23,21,0.88);
-  color:var(--gereni-text);
-  box-shadow:0 14px 28px rgba(0,0,0,0.45);
-}
-
-body[data-theme="dark"] .control-dropdown.is-open .control-dropdown__trigger {
-  background-color:var(--gereni-green);
-  color:#0f110d;
-}
-
-body[data-theme="dark"] .control-dropdown__panel {
-  background-color:rgba(19,19,18,0.95);
-  box-shadow:0 30px 58px rgba(0,0,0,0.55);
-}
-
-body[data-theme="dark"] .control-section__title {
-  color:rgba(234,215,192,0.75);
-}
-
-body[data-theme="dark"] .theme-toggle,
-body[data-theme="dark"] .language-toggle {
-  background-color:rgba(32,30,28,0.9);
-  box-shadow:0 10px 24px rgba(0,0,0,0.45);
-}
-
-body[data-theme="dark"] .theme-toggle button:hover,
-body[data-theme="dark"] .theme-toggle button:focus-visible,
-body[data-theme="dark"] .language-toggle button:hover,
-body[data-theme="dark"] .language-toggle button:focus-visible {
-  background-color:rgba(234,215,192,0.22);
-  color:var(--gereni-brown);
-}
-
-body[data-theme="dark"] .theme-toggle button.active,
-body[data-theme="dark"] .language-toggle button.active {
-  background-color:var(--gereni-brown);
-  color:#0f110d;
 }
 
 body[data-theme="dark"].inicio {
@@ -1504,26 +1469,6 @@ body.pdf-mode .pdf-document {
   position:relative;
   padding:0 0 clamp(2.5rem, 5vw, 3.25rem);
   text-align:center;
-}
-
-.menu-header__controls {
-  position:absolute;
-  top:0;
-  right:0;
-  display:flex;
-  align-items:center;
-}
-
-.menu-header__controls .control-dropdown__trigger {
-  padding:0.45rem 0.85rem;
-  font-size:0.78rem;
-  background-color:rgba(243,232,213,0.78);
-  color:var(--gereni-brown);
-  box-shadow:0 10px 24px rgba(91,58,41,0.18);
-}
-
-.menu-header__controls .control-dropdown__panel {
-  right:0;
 }
 
 .menu-header__inner {

--- a/styles/print.css
+++ b/styles/print.css
@@ -17,7 +17,7 @@
   .menu-empty {
     display: none !important;
   }
-  .language-toggle {
+  .preference-controls {
     display: none !important;
   }
   .home-link {


### PR DESCRIPTION
## Summary
- replace the header dropdown with icon-driven theme and language toggles on the home and menu pages
- update shared styles to support the new preference buttons and hide them when printing
- extend the theme and language scripts so the new controls stay in sync across language changes

## Testing
- npm run test:sync

------
https://chatgpt.com/codex/tasks/task_e_6901a17960348323bd9f72819c34fa75