### PR TITLE
Ensure menu exports load PDF layout script

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -16,6 +16,7 @@
   <script defer src="scripts/i18n.js"></script>
   <script defer src="scripts/theme.js"></script>
   <script defer src="scripts/loadMenu.js"></script>
+  <script defer src="scripts/pdfLayout.js"></script>
   <script defer src="scripts/pdfLink.js"></script>
   <script defer src="scripts/swRegister.js"></script>
   <script type="application/ld+json" id="menu-schema">


### PR DESCRIPTION
## Summary
- include scripts/pdfLayout.js on the menu page so the export task can prepare the PDF layout

## Testing
- npm run export:menu *(fails: missing libatk-1.0 on the container image)*

------
https://chatgpt.com/codex/tasks/task_e_6901ab2005fc8323a5ae0bc86e6f193c