### PR TITLE
Fix workflow to include promos manifest in artifact updates

### DIFF
--- a/.github/workflows/update-menu-artifacts.yml
+++ b/.github/workflows/update-menu-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Detect changes
         id: changes
         run: |
-          if [[ -n "$(git status --porcelain menu.html data/menu.json output/Menu_Gereni_digital.pdf output/Menu_Gereni_digital_*.pdf output/Menu_Gereni_print.pdf)" ]]; then
+          if [[ -n "$(git status --porcelain menu.html data/menu.json assets/promos/promos.json output/Menu_Gereni_digital.pdf output/Menu_Gereni_digital_*.pdf output/Menu_Gereni_print.pdf)" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -61,7 +61,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add menu.html data/menu.json output/Menu_Gereni_digital.pdf output/Menu_Gereni_digital_*.pdf output/Menu_Gereni_print.pdf
+          git add menu.html data/menu.json assets/promos/promos.json output/Menu_Gereni_digital.pdf output/Menu_Gereni_digital_*.pdf output/Menu_Gereni_print.pdf
           git commit -m "chore: auto-update menu artifacts [skip ci]"
           git pull --rebase origin main
           git push origin HEAD:main


### PR DESCRIPTION
## Summary
- include assets/promos/promos.json when detecting and committing workflow-generated artifacts so the update job can push cleanly

## Testing
- npm run check:all *(fails: network ENETUNREACH while validating social links)*

------
https://chatgpt.com/codex/tasks/task_e_6901b8220af883239ef34dadf2174f98