### PR TITLE
Add Halloween spider overlay and rollout plan

### DIFF
--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -56,6 +56,20 @@ To update progress:
 
 ---
 
+## Seasonal Activation: Halloween Takeover (Oct Sprint)
+**Goal:** Ship an immersive Halloween experience for the hero panel before tomorrow's event.
+
+- [x] Inject random spider scare overlay (`scripts/seasonalEffects.js`, `styles/main.css`)
+- [ ] Wire analytics event `halloween_spider_drop_seen`
+- [ ] Prepare ambient audio toggle + asset handoff
+- [ ] QA across Chrome, Safari, Android (see `content/halloween-experience-plan.md`)
+
+**Deliverables:**
+- Seasonal overlay with scalable scare factor
+- QA checklist complete with fallback strategy
+
+---
+
 ## Phase 4: Deployment & QA (Weeks 6–7)
 **Goal:** Ship production-ready version.
 

--- a/content/halloween-experience-plan.md
+++ b/content/halloween-experience-plan.md
@@ -1,0 +1,49 @@
+# Halloween Experience Game Plan
+
+**Date:** Tomorrow (see `PROJECT_PLAN.md` for baseline milestones)
+**Location:** Home hero panel + venue interior screens
+
+## Creative Direction
+- Over-the-top haunted lounge vibe that still matches the brand's deep purple and amber palette.
+- Focus on motion-driven surprises: glowing lantern haze, swooping bats, and now a *random spider drop scare*.
+- Keep intensity adjustable so we can respect accessibility preferences (`prefers-reduced-motion`).
+
+## Interactive Effects Checklist
+| Area | Effect | Notes |
+|------|--------|-------|
+| Landing hero (`inicio` body) | Seasonal overlay with glow, bats, lanterns | Already live. Review color balance after spider addition. |
+| Landing hero (`inicio` body) | **New** random spider drop | Ensure `scripts/seasonalEffects.js` stays performant; cap simultaneous spiders ≤ 4. |
+| Menu panel carousel | Flag featured Halloween cocktail card with `data-seasonal-effect="halloween"` so overlay activates immediately. |
+| Secondary CTA buttons | Add subtle shake on hover (CSS micro-interaction) if time allows. |
+| Social bar | Queue up #GereniHalloween hashtag with neon glow when overlay is active. |
+
+## Asset Readiness
+- [x] Seasonal overlay markup enhanced with spider layer (`scripts/seasonalEffects.js`).
+- [x] Spider visual styling and animation added to `styles/main.css`.
+- [ ] Confirm audio sting (15s ambient whisper or violin scrape) — optional scare toggle via mute icon.
+- [ ] Export updated hero background from Canva with extra shadow depth.
+- [ ] Gather high-res PNG of specialty cocktail garnish for supporting card art.
+
+## QA & Testing Plan
+1. **Desktop Chrome** — Verify spiders spawn in < 10s, do not accumulate indefinitely, and respond to reduced-motion setting.
+2. **iPad Safari** — Confirm overlays do not overflow, and pointer events remain disabled on the seasonal layer.
+3. **Low-end Android** — Measure animation smoothness; adjust `MAX_ACTIVE_SPIDERS` if < 45fps sustained.
+4. **Accessibility** — Toggle system reduced-motion to ensure overlay gracefully falls back with no spiders/bats.
+5. **Performance** — Use DevTools performance panel to ensure heap allocations for spiders are released on animation end.
+
+## Rollout Timeline
+| Time | Task |
+|------|------|
+| 08:30 | Final review of overlay visuals and run regression (`npm run check:all`). |
+| 09:00 | Sync menu content to highlight Halloween specials. |
+| 10:00 | QA sweep (desktop + mobile) with screenshots for social promo. |
+| 11:00 | Optional: Add ambient sound toggle if performance budget allows. |
+| 12:00 | Lunch & retro meeting — confirm scare factor with on-site staff. |
+| 14:00 | Publish PR + deploy to staging, share preview link with marketing. |
+| 16:00 | Buffer for emergency tweaks or animation pacing adjustments. |
+
+## Next Steps After Launch
+- Capture visitor reactions for social reels; mark best clips for evening push.
+- Add analytics event (`halloween_spider_drop_seen`) so we can measure engagement vs. bounce.
+- Prep quick disable flag (`?no-spiders`) in case guests report discomfort mid-event.
+- Document learnings in `PROJECT_PLAN.md` retrospective section after the event.

--- a/scripts/seasonalEffects.js
+++ b/scripts/seasonalEffects.js
@@ -4,9 +4,21 @@
   const HALLOWEEN_VALUE = 'halloween';
   const BODY_CLASS = 'holiday--halloween';
   const OVERLAY_CLASS = 'seasonal-overlay';
+  const SPIDER_LAYER_CLASS = 'seasonal-overlay__spider-layer';
+  const SPIDER_CLASS = 'seasonal-overlay__spider';
+  const SPIDER_BODY_CLASS = 'seasonal-overlay__spider-body';
+  const SPIDER_EYES_CLASS = 'seasonal-overlay__spider-eyes';
+  const SPIDER_WEB_CLASS = 'seasonal-overlay__spider-web';
+  const SPIDER_ANIMATION_CLASS = 'seasonal-overlay__spider--animating';
+  const MIN_SPIDER_INTERVAL = 4500;
+  const MAX_SPIDER_INTERVAL = 9000;
+  const MAX_ACTIVE_SPIDERS = 4;
 
   let observer = null;
   let overlay = null;
+  let spiderLayer = null;
+  let spiderTimeout = null;
+  const activeSpiders = new Set();
 
   const motionQuery = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
     ? window.matchMedia('(prefers-reduced-motion: reduce)')
@@ -35,6 +47,10 @@
       '</div>'
     ].join('');
     overlay = container;
+    spiderLayer = document.createElement('div');
+    spiderLayer.className = SPIDER_LAYER_CLASS;
+    spiderLayer.setAttribute('aria-hidden', 'true');
+    overlay.appendChild(spiderLayer);
     return overlay;
   }
 
@@ -42,10 +58,12 @@
     if (overlay && overlay.isConnected) {
       overlay.remove();
       overlay = null;
+      spiderLayer = null;
     }
   }
 
   function disableEffect() {
+    stopSpiders();
     removeOverlay();
     if (document.body) {
       document.body.classList.remove(BODY_CLASS);
@@ -78,6 +96,9 @@
     const overlayElement = ensureOverlay();
     if (overlayElement && !overlayElement.isConnected) {
       body.appendChild(overlayElement);
+    }
+    if (spiderLayer) {
+      startSpiders();
     }
   }
 
@@ -139,5 +160,82 @@
     document.addEventListener('DOMContentLoaded', init, { once: true });
   } else {
     init();
+  }
+
+  function createSpiderElement() {
+    if (!spiderLayer) {
+      return null;
+    }
+    const spider = document.createElement('div');
+    spider.className = `${SPIDER_CLASS} ${SPIDER_ANIMATION_CLASS}`;
+    const body = document.createElement('span');
+    body.className = SPIDER_BODY_CLASS;
+    const eyes = document.createElement('span');
+    eyes.className = SPIDER_EYES_CLASS;
+    const thread = document.createElement('span');
+    thread.className = SPIDER_WEB_CLASS;
+    spider.appendChild(body);
+    spider.appendChild(eyes);
+    spider.appendChild(thread);
+
+    const offset = Math.random();
+    const horizontalPosition = Math.round(offset * 100);
+    spider.style.setProperty('--spider-left', `${horizontalPosition}%`);
+    spider.style.setProperty('--spider-scale', String(0.85 + Math.random() * 0.5));
+    const duration = 4 + Math.random() * 3;
+    spider.style.setProperty('--spider-duration', `${duration.toFixed(2)}s`);
+    const swayDirection = Math.random() > 0.5 ? '1' : '-1';
+    spider.style.setProperty('--spider-sway-direction', swayDirection);
+
+    spider.addEventListener('animationend', () => {
+      activeSpiders.delete(spider);
+      spider.remove();
+    }, { once: true });
+
+    activeSpiders.add(spider);
+    spiderLayer.appendChild(spider);
+    return spider;
+  }
+
+  function scheduleNextSpider() {
+    if (spiderTimeout) {
+      clearTimeout(spiderTimeout);
+    }
+    const delay = Math.round(
+      MIN_SPIDER_INTERVAL + Math.random() * (MAX_SPIDER_INTERVAL - MIN_SPIDER_INTERVAL)
+    );
+    spiderTimeout = window.setTimeout(() => {
+      spiderTimeout = null;
+      if (activeSpiders.size < MAX_ACTIVE_SPIDERS) {
+        createSpiderElement();
+      }
+      scheduleNextSpider();
+    }, delay);
+  }
+
+  function startSpiders() {
+    if (!spiderLayer || spiderTimeout) {
+      return;
+    }
+    // Warm up with an immediate spider to reinforce the Halloween mood.
+    if (activeSpiders.size === 0) {
+      createSpiderElement();
+    }
+    scheduleNextSpider();
+  }
+
+  function stopSpiders() {
+    if (spiderTimeout) {
+      clearTimeout(spiderTimeout);
+      spiderTimeout = null;
+    }
+    if (activeSpiders.size > 0) {
+      activeSpiders.forEach((spider) => {
+        if (spider && spider.isConnected) {
+          spider.remove();
+        }
+      });
+      activeSpiders.clear();
+    }
   }
 })();

--- a/styles/main.css
+++ b/styles/main.css
@@ -2144,6 +2144,105 @@ body.inicio.holiday--halloween::after {
   animation:seasonalLanternRear 16s ease-in-out infinite;
 }
 
+.seasonal-overlay__spider-layer {
+  position:absolute;
+  inset:-10% 0 0;
+  pointer-events:none;
+  overflow:visible;
+  z-index:2;
+}
+
+.seasonal-overlay__spider {
+  position:absolute;
+  top:-18%;
+  left:var(--spider-left, 50%);
+  width:64px;
+  height:120px;
+  transform-origin:50% 0;
+  transform:translate3d(-50%, -120%, 0) scale(var(--spider-scale, 1));
+  animation:seasonalSpiderDrop var(--spider-duration, 5.5s) cubic-bezier(0.32, 0, 0.18, 1) forwards;
+  filter:drop-shadow(0 10px 22px rgba(0,0,0,0.6));
+}
+
+.seasonal-overlay__spider-body {
+  position:absolute;
+  top:48px;
+  left:50%;
+  width:38px;
+  height:46px;
+  transform:translate(-50%, -50%);
+  border-radius:45% 45% 55% 55%;
+  background:
+    radial-gradient(circle at 40% 35%, rgba(69,63,72,0.35) 0%, rgba(69,63,72,0) 60%),
+    radial-gradient(circle at 70% 30%, rgba(255,73,98,0.45) 0%, rgba(255,73,98,0) 55%),
+    radial-gradient(circle at 50% 60%, rgba(16,13,21,0.95) 0%, rgba(16,13,21,0.1) 82%);
+}
+
+.seasonal-overlay__spider-eyes {
+  position:absolute;
+  top:56px;
+  left:50%;
+  width:26px;
+  height:12px;
+  transform:translateX(-50%);
+  display:flex;
+  justify-content:space-between;
+}
+
+.seasonal-overlay__spider-eyes::before,
+.seasonal-overlay__spider-eyes::after {
+  content:'';
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  background:radial-gradient(circle at 40% 40%, rgba(255,255,255,0.75) 0%, rgba(255,68,80,0.9) 45%, rgba(255,68,80,0.15) 100%);
+  box-shadow:0 0 8px rgba(255,68,80,0.85);
+  animation:seasonalSpiderBlink 4.5s ease-in-out infinite;
+}
+
+.seasonal-overlay__spider-web {
+  position:absolute;
+  top:0;
+  left:50%;
+  width:2px;
+  height:100%;
+  transform:translateX(-50%);
+  transform-origin:50% 0;
+  background:linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(218,206,255,0.45) 35%, rgba(128,105,182,0.4) 100%);
+  opacity:0.85;
+  animation:seasonalSpiderThread var(--spider-duration, 5.5s) ease-out forwards;
+}
+
+.seasonal-overlay__spider::before,
+.seasonal-overlay__spider::after {
+  content:'';
+  position:absolute;
+  left:50%;
+  width:64px;
+  height:56px;
+  transform:translateX(-50%);
+  border-radius:50%;
+}
+
+.seasonal-overlay__spider::before {
+  top:58px;
+  background:
+    linear-gradient(105deg, rgba(12,8,15,0.92) 40%, rgba(37,31,52,0.65) 100%);
+  clip-path:polygon(6% 54%, 22% 34%, 36% 62%, 50% 32%, 64% 60%, 78% 38%, 94% 58%, 94% 72%, 79% 64%, 64% 86%, 52% 60%, 40% 90%, 23% 64%, 6% 76%);
+}
+
+.seasonal-overlay__spider::after {
+  top:62px;
+  background:
+    linear-gradient(140deg, rgba(18,15,24,0.95) 35%, rgba(0,0,0,0.4) 100%);
+  clip-path:polygon(8% 52%, 20% 30%, 36% 55%, 50% 28%, 64% 52%, 80% 27%, 93% 50%, 83% 68%, 67% 46%, 52% 80%, 38% 44%, 24% 80%, 11% 54%);
+  filter:drop-shadow(0 5px 14px rgba(0,0,0,0.55));
+}
+
+.seasonal-overlay__spider--animating {
+  --spider-sway-direction:1;
+}
+
 @keyframes holidayFlicker {
   0% {
     opacity:0.55;
@@ -2231,6 +2330,67 @@ body.inicio.holiday--halloween::after {
   }
 }
 
+@keyframes seasonalSpiderDrop {
+  0% {
+    opacity:0;
+    transform:translate3d(calc(-50% + (var(--spider-sway-direction, 1) * -30px)), -140%, 0) scale(var(--spider-scale, 1));
+  }
+  20% {
+    opacity:1;
+    transform:translate3d(calc(-50% + (var(--spider-sway-direction, 1) * 12px)), 5%, 0) scale(calc(var(--spider-scale, 1) * 1.08));
+  }
+  45% {
+    transform:translate3d(calc(-50% - (var(--spider-sway-direction, 1) * 14px)), 28%, 0) scale(calc(var(--spider-scale, 1) * 1.02));
+  }
+  65% {
+    transform:translate3d(calc(-50% + (var(--spider-sway-direction, 1) * 10px)), 36%, 0) scale(calc(var(--spider-scale, 1) * 1.05));
+  }
+  78% {
+    transform:translate3d(calc(-50% - (var(--spider-sway-direction, 1) * 6px)), 24%, 0) scale(var(--spider-scale, 1));
+  }
+  100% {
+    opacity:0;
+    transform:translate3d(calc(-50% + (var(--spider-sway-direction, 1) * 20px)), -160%, 0) scale(calc(var(--spider-scale, 1) * 0.75));
+  }
+}
+
+@keyframes seasonalSpiderThread {
+  0% {
+    transform:scaleY(0);
+    opacity:0;
+  }
+  12% {
+    transform:scaleY(1);
+    opacity:0.9;
+  }
+  65% {
+    transform:scaleY(0.95);
+    opacity:0.9;
+  }
+  85% {
+    transform:scaleY(0.35);
+    opacity:0.7;
+  }
+  100% {
+    transform:scaleY(0);
+    opacity:0;
+  }
+}
+
+@keyframes seasonalSpiderBlink {
+  0%, 85%, 100% {
+    transform:scaleY(1);
+    filter:drop-shadow(0 0 8px rgba(255,68,80,0.85));
+  }
+  88% {
+    transform:scaleY(0.25);
+    filter:drop-shadow(0 0 4px rgba(255,68,80,0.65));
+  }
+  92% {
+    transform:scaleY(1.05);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   body.inicio.holiday--halloween::after {
     animation:none;
@@ -2245,13 +2405,18 @@ body.inicio.holiday--halloween::after {
   body.inicio.holiday--halloween .seasonal-overlay__glow,
   body.inicio.holiday--halloween .seasonal-overlay__bat,
   body.inicio.holiday--halloween .seasonal-overlay__lantern,
-  body.inicio.holiday--halloween .seasonal-overlay__lantern::after {
+  body.inicio.holiday--halloween .seasonal-overlay__lantern::after,
+  body.inicio.holiday--halloween .seasonal-overlay__spider,
+  body.inicio.holiday--halloween .seasonal-overlay__spider-web,
+  body.inicio.holiday--halloween .seasonal-overlay__spider-eyes::before,
+  body.inicio.holiday--halloween .seasonal-overlay__spider-eyes::after {
     animation:none !important;
     transform:none !important;
   }
 
   body.inicio.holiday--halloween .seasonal-overlay__bats,
-  body.inicio.holiday--halloween .seasonal-overlay__lanterns {
+  body.inicio.holiday--halloween .seasonal-overlay__lanterns,
+  body.inicio.holiday--halloween .seasonal-overlay__spider-layer {
     display:none;
   }
 }


### PR DESCRIPTION
## Summary
- add a spider scare overlay that spawns random crawlers when the Halloween card is active
- style the new spider visuals and motion while respecting reduced-motion preferences
- document the activation plan in a dedicated Halloween experience brief and update the project plan

## Testing
- npm run test:sync

------
https://chatgpt.com/codex/tasks/task_e_6901bc672fcc8323a90fa441d5b525fd