### PR TITLE
Make menu logo link back to home page

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -839,7 +839,23 @@
     <h1 class="sr-only" data-i18n-es="Menú - Gereni Bar y Restaurante" data-i18n-en="Menu - Gereni Bar &amp; Restaurant">
       Menú - Gereni Bar y Restaurante
     </h1>
-    <img src="assets/logo-gereni-bar-restaurant.png" alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-es="Logo de Gereni Bar y Restaurante" data-i18n-en="Gereni Bar &amp; Restaurant logo" />
+    <a
+      href="index.html"
+      class="logo-link"
+      aria-label="Ir al inicio"
+      data-i18n-attr="aria-label"
+      data-i18n-es="Ir al inicio"
+      data-i18n-en="Go to home page"
+    >
+      <img
+        src="assets/logo-gereni-bar-restaurant.png"
+        alt="Logo de Gereni Bar y Restaurante"
+        class="logo"
+        data-i18n-attr="alt"
+        data-i18n-es="Logo de Gereni Bar y Restaurante"
+        data-i18n-en="Gereni Bar &amp; Restaurant logo"
+      />
+    </a>
   </header>
   <main>
     <div class="menu-container" id="menu-container">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1098,6 +1098,24 @@ body.inicio header::after {
   text-decoration:underline;
 }
 
+.logo-link {
+  display:inline-block;
+  margin:0 auto;
+  border-radius:16px;
+  transition:transform 0.2s ease;
+  text-decoration:none;
+}
+
+.logo-link:focus-visible {
+  outline:3px solid var(--gereni-green);
+  outline-offset:6px;
+  text-decoration:none;
+}
+
+.logo-link:hover {
+  transform:scale(1.02);
+}
+
 .logo {
   max-width:200px;
   margin:0 auto;


### PR DESCRIPTION
## Summary
- wrap the menu logo in a link that navigates back to the home page
- style the linked logo to keep centering and add focus and hover affordances

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69026d3633d88323ab11ba0c111befd1