### PR TITLE
Remove ambience sound toggle from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,18 +84,6 @@
      <span class="preference-button__value" data-lang-label="">Español</span>
     </span>
    </button>
-    <button aria-label="Silenciar ambientación" class="preference-button preference-button--sound" data-i18n-attr="aria-label" data-i18n-en="Toggle ambience sound" data-i18n-es="Silenciar ambientación" data-sound-toggle="" data-sound-state="on" type="button">
-     <span aria-hidden="true" class="preference-button__icon">
-      <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-       <path d="M7.5 12h4l5.5-5v18l-5.5-5h-4a1.5 1.5 0 0 1-1.5-1.5v-5A1.5 1.5 0 0 1 7.5 12Z" fill="currentColor"/>
-       <path d="m23 12 4 4m0 0-4 4" stroke="currentColor" stroke-linecap="round" stroke-width="2"/>
-      </svg>
-     </span>
-     <span class="preference-button__text">
-      <span class="preference-button__hint" data-i18n-en="Sound" data-i18n-es="Sonido">Sonido</span>
-      <span class="preference-button__value" data-i18n-en="On" data-i18n-es="Activado" data-sound-label="">Activado</span>
-     </span>
-    </button>
    </div>
   </div>
 <img alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-en="Gereni Bar &amp; Restaurant logo" data-i18n-es="Logo de Gereni Bar y Restaurante" src="assets/logo-gereni-bar-restaurant.png"/>


### PR DESCRIPTION
## Summary
- remove the ambience sound preference button from the home page header

## Testing
- npm run check:all *(fails: social link validation cannot reach facebook.com and instagram.com)*
- npm run test:sync
- npm run test:a11y

------
https://chatgpt.com/codex/tasks/task_e_690286125b548323a1f3dce2de4aca46