### PR TITLE
Replace menu scroll slider with top/bottom jump buttons

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -1704,22 +1704,6 @@
           <path d="M12 5.5a1 1 0 0 1 .7.29l6 6a1 1 0 0 1-1.4 1.42L13 8.91V18a1 1 0 0 1-2 0V8.9l-4.3 4.3a1 1 0 1 1-1.4-1.42l6-6A1 1 0 0 1 12 5.5Z" fill="currentColor" />
         </svg>
       </button>
-      <div class="menu-scroll-helper__slider" data-scroll-slider-wrapper>
-        <input
-          type="range"
-          min="0"
-          max="1"
-          value="0"
-          step="1"
-          class="menu-scroll-helper__range"
-          data-scroll-slider
-          aria-label="Desplazarse por el menú"
-          data-i18n-attr="aria-label"
-          data-i18n-es="Desplazarse por el menú"
-          data-i18n-en="Scroll through the menu"
-        />
-        <span class="menu-scroll-helper__progress" data-scroll-progress aria-hidden="true">0%</span>
-      </div>
       <button
         type="button"
         class="menu-scroll-helper__button menu-scroll-helper__button--down"

--- a/scripts/scrollHelper.js
+++ b/scripts/scrollHelper.js
@@ -13,21 +13,16 @@
 
   function init() {
     const helper = document.querySelector('[data-scroll-helper]');
-    const slider = helper ? helper.querySelector('[data-scroll-slider]') : null;
-
-    if (!helper || !slider) {
+    if (!helper) {
       return;
     }
 
     const topButton = helper.querySelector('[data-scroll-top]');
     const bottomButton = helper.querySelector('[data-scroll-bottom]');
-    const progress = helper.querySelector('[data-scroll-progress]');
     const doc = document.documentElement;
     const body = document.body;
 
     let maxScroll = 0;
-    let isUserSliding = false;
-    let scrollFrame = null;
     let layoutFrame = null;
 
     function getScrollTop() {
@@ -37,15 +32,6 @@
         (body ? body.scrollTop : 0) ||
         0
       );
-    }
-
-    function updateProgressDisplay(current) {
-      const bounded = maxScroll > 0 ? Math.min(Math.max(current, 0), maxScroll) : 0;
-      const percent = maxScroll > 0 ? Math.round((bounded / maxScroll) * 100) : 0;
-      if (progress) {
-        progress.textContent = `${percent}%`;
-      }
-      slider.style.setProperty('--scroll-progress', `${percent}%`);
     }
 
     function computeMaxScroll() {
@@ -61,32 +47,12 @@
       const viewport = window.innerHeight || doc.clientHeight || 0;
       maxScroll = Math.max(docHeight - viewport, 0);
       const disabled = maxScroll <= MIN_SCROLL_THRESHOLD;
-      slider.max = maxScroll > 0 ? maxScroll : 1;
-      slider.disabled = disabled;
       helper.hidden = disabled;
-      if (disabled) {
-        slider.value = '0';
-        updateProgressDisplay(0);
-      }
-    }
-
-    function syncToScroll() {
-      const top = Math.max(0, Math.min(getScrollTop(), maxScroll));
-      slider.value = String(top);
-      updateProgressDisplay(top);
+      updateButtonState();
     }
 
     function handleScroll() {
-      if (isUserSliding) {
-        return;
-      }
-      if (scrollFrame) {
-        return;
-      }
-      scrollFrame = window.requestAnimationFrame(() => {
-        scrollFrame = null;
-        syncToScroll();
-      });
+      window.requestAnimationFrame(updateButtonState);
     }
 
     function scheduleLayoutUpdate() {
@@ -96,7 +62,6 @@
       layoutFrame = window.requestAnimationFrame(() => {
         layoutFrame = null;
         computeMaxScroll();
-        syncToScroll();
       });
     }
 
@@ -107,38 +72,20 @@
       const target = Math.max(0, Math.min(position, maxScroll));
       const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
       window.scrollTo({ top: target, behavior });
-      updateProgressDisplay(target);
+      window.requestAnimationFrame(updateButtonState);
     }
 
-    slider.addEventListener('input', () => {
-      if (slider.disabled) {
-        return;
+    function updateButtonState() {
+      const top = Math.max(0, Math.min(getScrollTop(), maxScroll));
+      const nearTop = top <= 16;
+      const nearBottom = maxScroll - top <= 16;
+      if (topButton) {
+        topButton.disabled = nearTop;
       }
-      const value = Number(slider.value);
-      scrollToPosition(Number.isFinite(value) ? value : 0);
-    });
-
-    slider.addEventListener('change', () => {
-      if (!isUserSliding) {
-        syncToScroll();
+      if (bottomButton) {
+        bottomButton.disabled = nearBottom;
       }
-    });
-
-    slider.addEventListener('pointerdown', () => {
-      isUserSliding = true;
-    });
-
-    const stopSliding = () => {
-      if (!isUserSliding) {
-        return;
-      }
-      isUserSliding = false;
-      syncToScroll();
-    };
-
-    slider.addEventListener('pointerup', stopSliding);
-    slider.addEventListener('pointercancel', stopSliding);
-    slider.addEventListener('blur', stopSliding);
+    }
 
     topButton?.addEventListener('click', event => {
       event.preventDefault();
@@ -157,10 +104,10 @@
     document.addEventListener('gereni:menuRendered', scheduleLayoutUpdate);
 
     computeMaxScroll();
-    syncToScroll();
+    updateButtonState();
 
     if (reduceMotionQuery) {
-      reduceMotionQuery.addEventListener('change', syncToScroll);
+      reduceMotionQuery.addEventListener('change', updateButtonState);
     }
   }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -1703,202 +1703,75 @@ body.pdf-mode .pdf-document {
 
 .menu-scroll-helper {
   position:fixed;
-  right:clamp(0.75rem, 4vw, 1.75rem);
-  bottom:clamp(1.25rem, 6vw, 2.75rem);
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  gap:0.6rem;
-  padding:0.55rem 0.7rem;
-  border-radius:999px;
-  background:rgba(243,232,213,0.92);
-  border:1px solid rgba(91,58,41,0.18);
-  box-shadow:0 16px 32px rgba(91,58,41,0.24);
-  backdrop-filter:blur(18px);
-  -webkit-backdrop-filter:blur(18px);
+  inset:0;
+  pointer-events:none;
   z-index:120;
-  transition:opacity 0.2s ease, transform 0.2s ease;
-}
-
-:root[data-theme="dark"] .menu-scroll-helper {
-  background:rgba(25,24,22,0.85);
-  border-color:rgba(234,215,192,0.22);
-  box-shadow:0 20px 42px rgba(0,0,0,0.45);
 }
 
 .menu-scroll-helper__button {
-  width:2.35rem;
-  height:2.35rem;
+  position:absolute;
+  right:clamp(0.85rem, 3vw, 2rem);
+  width:clamp(2.75rem, 5vw, 3.2rem);
+  height:clamp(2.75rem, 5vw, 3.2rem);
   border-radius:999px;
-  border:none;
-  display:inline-flex;
+  border:1px solid rgba(91,58,41,0.18);
+  display:flex;
   align-items:center;
   justify-content:center;
-  background:rgba(91,58,41,0.14);
+  background:rgba(243,232,213,0.88);
   color:var(--gereni-brown);
   cursor:pointer;
-  transition:background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  box-shadow:0 16px 32px rgba(91,58,41,0.22);
+  backdrop-filter:blur(18px);
+  -webkit-backdrop-filter:blur(18px);
+  transition:background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+  pointer-events:auto;
+}
+
+:root[data-theme="dark"] .menu-scroll-helper__button {
+  background:rgba(25,24,22,0.82);
+  border-color:rgba(234,215,192,0.18);
+  color:var(--gereni-cream);
+  box-shadow:0 18px 40px rgba(0,0,0,0.45);
+}
+
+.menu-scroll-helper__button--up {
+  top:clamp(1.1rem, 6vw, 2.25rem);
+}
+
+.menu-scroll-helper__button--down {
+  bottom:clamp(1.1rem, 6vw, 2.25rem);
 }
 
 .menu-scroll-helper__button svg {
-  width:1.25rem;
-  height:1.25rem;
+  width:1.35rem;
+  height:1.35rem;
 }
 
 .menu-scroll-helper__button:hover,
 .menu-scroll-helper__button:focus-visible {
-  background:rgba(91,58,41,0.24);
+  background:rgba(91,58,41,0.22);
   color:var(--gereni-green);
   outline:none;
   transform:translateY(-1px);
 }
 
-.menu-scroll-helper__slider {
-  display:inline-flex;
-  align-items:center;
-  gap:0.55rem;
+.menu-scroll-helper__button:disabled {
+  opacity:0.38;
+  cursor:default;
+  transform:none;
 }
 
-.menu-scroll-helper__range {
-  --range-thickness:0.4rem;
-  --thumb-size:1.05rem;
-  --scroll-progress:0%;
-  width:clamp(140px, 62vw, 260px);
-  height:var(--range-thickness);
-  appearance:none;
-  background:linear-gradient(
-    to right,
-    rgba(75,106,61,0.45) 0%,
-    rgba(75,106,61,0.45) var(--scroll-progress),
-    rgba(91,58,41,0.18) var(--scroll-progress),
-    rgba(91,58,41,0.18) 100%
-  );
-  border-radius:999px;
-  cursor:pointer;
-}
-
-.menu-scroll-helper__range:focus-visible {
-  outline:2px solid var(--gereni-green);
-  outline-offset:4px;
-}
-
-.menu-scroll-helper__range::-webkit-slider-runnable-track {
-  height:var(--range-thickness);
-  background:transparent;
-  border-radius:999px;
-}
-
-.menu-scroll-helper__range::-webkit-slider-thumb {
-  -webkit-appearance:none;
-  width:var(--thumb-size);
-  height:var(--thumb-size);
-  border-radius:50%;
-  background:var(--gereni-green);
-  border:2px solid var(--gereni-card);
-  box-shadow:0 6px 18px rgba(75,106,61,0.28);
-  margin-top:calc((var(--range-thickness) - var(--thumb-size)) / 2);
-}
-
-.menu-scroll-helper__range::-moz-range-track {
-  height:var(--range-thickness);
-  background:rgba(91,58,41,0.18);
-  border-radius:999px;
-}
-
-.menu-scroll-helper__range::-moz-range-progress {
-  height:var(--range-thickness);
-  background:rgba(75,106,61,0.45);
-  border-radius:999px;
-}
-
-.menu-scroll-helper__range::-moz-range-thumb {
-  width:var(--thumb-size);
-  height:var(--thumb-size);
-  border-radius:50%;
-  background:var(--gereni-green);
-  border:2px solid var(--gereni-card);
-  box-shadow:0 6px 18px rgba(75,106,61,0.28);
-}
-
-.menu-scroll-helper__progress {
-  min-width:2.3rem;
-  font-size:0.76rem;
-  font-weight:600;
-  color:var(--gereni-muted);
-  text-align:center;
-  font-variant-numeric:tabular-nums;
-}
-
-@media (min-width: 600px) {
-  .menu-scroll-helper {
-    padding-inline:0.85rem;
-    gap:0.75rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .menu-scroll-helper {
-    padding:0.5rem 0.6rem;
-    gap:0.5rem;
-  }
-
+@media (max-width: 520px) {
   .menu-scroll-helper__button {
-    width:2.15rem;
-    height:2.15rem;
-  }
-
-  .menu-scroll-helper__slider {
-    gap:0.45rem;
-  }
-
-  .menu-scroll-helper__range {
-    width:clamp(110px, 58vw, 180px);
-    --range-thickness:0.36rem;
-    --thumb-size:0.95rem;
-  }
-
-  .menu-scroll-helper__progress {
-    display:none;
-  }
-}
-
-@media (min-width: 960px) {
-  .menu-scroll-helper {
-    right:clamp(1rem, 3vw, 2.5rem);
-    bottom:auto;
-    top:50%;
-    transform:translateY(-50%);
-    flex-direction:column;
-    gap:0.85rem;
-    padding:0.85rem 0.7rem;
-  }
-
-  .menu-scroll-helper__slider {
-    flex-direction:column;
-    gap:0.75rem;
-  }
-
-  .menu-scroll-helper__range {
-    width:var(--range-thickness);
-    height:clamp(220px, 60vh, 360px);
-    writing-mode:bt-lr;
-    -webkit-appearance:slider-vertical;
-    background:linear-gradient(
-      to top,
-      rgba(75,106,61,0.45) 0%,
-      rgba(75,106,61,0.45) var(--scroll-progress),
-      rgba(91,58,41,0.18) var(--scroll-progress),
-      rgba(91,58,41,0.18) 100%
-    );
-  }
-
-  .menu-scroll-helper__progress {
-    min-width:auto;
+    right:clamp(0.65rem, 4vw, 1.5rem);
+    width:2.5rem;
+    height:2.5rem;
+    box-shadow:0 12px 24px rgba(91,58,41,0.25);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .menu-scroll-helper,
   .menu-scroll-helper__button {
     transition:none;
   }


### PR DESCRIPTION
## Summary
- replace the menu scroll helper slider with dedicated top and bottom jump buttons
- restyle the floating controls to position arrow buttons at the top and bottom right of the page
- simplify the scroll helper script to manage button visibility and smooth scrolling

## Testing
- npm run check:menu

------
https://chatgpt.com/codex/tasks/task_e_6903bc88db108323bb5d2f71120b4d06