### PR TITLE
Implement network-first caching for shell assets

### DIFF
--- a/assets/promos/promos.json
+++ b/assets/promos/promos.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2025-10-30T19:42:35.668Z",
+  "generatedAt": "2025-10-30T19:53:01.208Z",
   "items": [
     {
       "src": "assets/promos/noche_mascarada.jpg",
-      "updatedAt": "2025-10-30T19:42:26.344Z"
+      "updatedAt": "2025-10-30T19:43:24.043Z"
     }
   ]
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -93,32 +93,21 @@ const cacheFirst = async (request) => {
   return response;
 };
 
-const staleWhileRevalidate = async (request, event) => {
+const networkFirstShell = async (request) => {
   const cache = await caches.open(SHELL_CACHE);
-  const cached = await cache.match(request);
-
-  const networkFetch = fetch(request)
-    .then((response) => {
-      if (response && response.ok) {
-        cache.put(request, response.clone());
-      }
-      return response;
-    })
-    .catch(() => undefined);
-
-  if (cached) {
-    if (event) {
-      event.waitUntil(networkFetch);
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      cache.put(request, response.clone());
     }
-    return cached;
-  }
-
-  const response = await networkFetch;
-  if (response) {
     return response;
+  } catch (error) {
+    const cached = await cache.match(request);
+    if (cached) {
+      return cached;
+    }
+    throw error;
   }
-
-  throw new Error('Resource unavailable: not in cache and network fetch failed');
 };
 
 const networkFirstData = async (request) => {
@@ -229,7 +218,7 @@ self.addEventListener('fetch', (event) => {
     url.pathname.endsWith('.css') ||
     url.pathname.endsWith('.js')
   ) {
-    event.respondWith(staleWhileRevalidate(request, event));
+    event.respondWith(networkFirstShell(request));
     return;
   }
 


### PR DESCRIPTION
## Summary
- add a network-first helper for shell assets to prefer fresh CSS and JS
- switch the service worker fetch handler for styles/scripts to use the network-first strategy
- capture the regenerated promos manifest from the fallback build

## Testing
- npm run build:fallback

------
https://chatgpt.com/codex/tasks/task_e_6903c1e8bef88323a0fdf7e2303d1a6d