### PR TITLE
Lighten hero overlay for El Rancho image

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -15,7 +15,7 @@
   --home-highlight-card-glow:rgba(255,214,162,0.28);
   --home-highlight-card-glow-secondary:rgba(146,176,135,0.32);
   --home-background-image:url('../assets/El_Rancho.jpg');
-  --home-background-overlay:linear-gradient(rgba(243,232,213,0.68), rgba(243,232,213,0.72));
+  --home-background-overlay:linear-gradient(rgba(243,232,213,0.18), rgba(243,232,213,0.28));
   --home-background-blend-mode:normal;
   --home-background-position:center 8%;
   --home-background-position-mobile:center 18%;
@@ -37,8 +37,8 @@
   --home-highlight-card-border:rgba(234,215,192,0.28);
   --home-highlight-card-glow:rgba(111,147,98,0.32);
   --home-highlight-card-glow-secondary:rgba(255,214,162,0.18);
-  --home-background-overlay:linear-gradient(rgba(14,14,14,0.6), rgba(14,14,14,0.78));
-  --home-background-blend-mode:multiply;
+  --home-background-overlay:linear-gradient(rgba(22,22,22,0.28), rgba(22,22,22,0.38));
+  --home-background-blend-mode:soft-light;
   --home-background-position:center 8%;
   --home-background-position-mobile:center 18%;
 }


### PR DESCRIPTION
## Summary
- reduce the light theme hero gradient opacity so the El Rancho background shows through
- switch the dark theme overlay to a softer gradient with soft-light blending for clearer imagery

## Testing
- python -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_6903c134af288323aea9511ec408bf84