### PR TITLE
Collapse menu sections by default on mobile

### DIFF
--- a/scripts/collapsibleSections.js
+++ b/scripts/collapsibleSections.js
@@ -189,7 +189,7 @@
     const storedValue = sectionId ? storedState[sectionId] : undefined;
     const collapsedPreference = storedValue === 'collapsed';
     const expandedPreference = storedValue === 'expanded';
-    let expanded = true;
+    let expanded;
 
     if (collapsedPreference) {
       expanded = false;


### PR DESCRIPTION
## Summary
- collapse menu sections by default when the viewport matches the mobile breakpoint so categories start closed on phones
- retain in-session expanded choices while persisting collapsed preferences via local storage

## Testing
- npm run check:menu
- npm run test:scroll

------
https://chatgpt.com/codex/tasks/task_e_6903d0cff4c48323a9c964e7a17edcac