### PR TITLE
Fix mobile layout overflow

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -63,6 +63,7 @@
 
 html {
   background-color: var(--gereni-cream);
+  overflow-x:hidden;
 }
 
 * {
@@ -76,6 +77,7 @@ body {
   background-color:var(--gereni-cream);
   color:var(--gereni-text);
   line-height:1.5;
+  overflow-x:hidden;
 }
 
 @supports (min-height: 100dvh) {
@@ -966,7 +968,10 @@ body[data-theme="dark"] .menu-header__controls .preference-button {
 body.inicio header::before {
   content:'';
   position:absolute;
-  inset:-48% -32% 44%;
+  top:-48%;
+  right:max(-32%, -2rem);
+  bottom:44%;
+  left:max(-32%, -2rem);
   background:radial-gradient(circle at 50% -15%, rgba(255,248,234,0.92) 0%, rgba(255,248,234,0.48) 42%, rgba(255,248,234,0) 75%);
   pointer-events:none;
   z-index:-1;
@@ -976,7 +981,10 @@ body.inicio header::before {
 body.inicio header::after {
   content:'';
   position:absolute;
-  inset:-62% -45% 40%;
+  top:-62%;
+  right:max(-45%, -2.75rem);
+  bottom:40%;
+  left:max(-45%, -2.75rem);
   background:repeating-conic-gradient(from -90deg at 50% -22%, rgba(255,214,162,0.42) 0deg, rgba(255,214,162,0.42) 7deg, rgba(255,214,162,0) 14deg);
   opacity:0.7;
   pointer-events:none;


### PR DESCRIPTION
## Summary
- prevent horizontal overflow on the home header background flourishes so mobile layouts no longer scroll sideways
- hide any residual horizontal overflow at the document level to keep the layout centered on small screens

## Testing
- npm run test:a11y

------
https://chatgpt.com/codex/tasks/task_e_6903e28a27ac8323b66bca89bb8df70f