### PR TITLE
Add photos to menu items for remaining assets

### DIFF
--- a/data/menu.json
+++ b/data/menu.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2025-10-31T00:57:28.499Z",
+  "updatedAt": "2025-10-31T03:45:38.000Z",
   "sections": [
     {
       "title": {
@@ -16,7 +16,8 @@
             "es": "Acompañadas con papas y ensalada.",
             "en": "Served with fries and salad."
           },
-          "price": "₡4.800"
+          "price": "₡4.800",
+          "image": "assets/photos/Fajitas-Mixtas.png"
         },
         {
           "name": {
@@ -38,7 +39,8 @@
             "es": "Acompañadas con papas y ensalada.",
             "en": "Served with fries and salad."
           },
-          "price": "₡3.700"
+          "price": "₡3.700",
+          "image": "assets/photos/Nuggets-de-Pollo.png"
         },
         {
           "name": {
@@ -60,7 +62,8 @@
             "es": "Preparado fresco del día.",
             "en": "Prepared fresh each day."
           },
-          "price": "₡3.000"
+          "price": "₡3.000",
+          "image": "assets/photos/Ceviche-de-Pescado.png"
         },
         {
           "name": {
@@ -116,7 +119,8 @@
             "es": "Porción casera del día.",
             "en": "Homestyle portion of the day."
           },
-          "price": "₡2.000"
+          "price": "₡2.000",
+          "image": "assets/photos/Pozol.png"
         },
         {
           "name": {
@@ -127,7 +131,8 @@
             "es": "2 unidades bañadas en salsa de tomate.",
             "en": "Two pieces covered in tomato sauce."
           },
-          "price": "₡1.200"
+          "price": "₡1.200",
+          "image": "assets/photos/Canelones.png"
         },
         {
           "name": {
@@ -203,7 +208,8 @@
             "es": "Acompañado de papas y ensalada.",
             "en": "Served with fries and salad."
           },
-          "price": "₡4.520"
+          "price": "₡4.520",
+          "image": "assets/photos/Arroz-con-Camarones.png"
         }
       ]
     },
@@ -246,7 +252,8 @@
             "es": "Porción crujiente de la casa.",
             "en": "House crispy pork portion."
           },
-          "price": "₡4.000"
+          "price": "₡4.000",
+          "image": "assets/photos/Chicharrones.png"
         },
         {
           "name": {
@@ -335,7 +342,8 @@
             "es": "Salsa a elegir, acompañadas de papas.",
             "en": "Your choice of sauce, served with fries."
           },
-          "price": "₡5.000"
+          "price": "₡5.000",
+          "image": "assets/photos/Alitas-de-Pollo.png"
         },
         {
           "name": {
@@ -346,7 +354,8 @@
             "es": "Salsa a elegir, acompañadas de papas.",
             "en": "Your choice of sauce, served with fries."
           },
-          "price": "₡7.000"
+          "price": "₡7.000",
+          "image": "assets/photos/Alitas-de-Pollo.png"
         },
         {
           "name": {
@@ -357,7 +366,8 @@
             "es": "Salsa a elegir, acompañadas de papas.",
             "en": "Your choice of sauce, served with fries."
           },
-          "price": "₡9.000"
+          "price": "₡9.000",
+          "image": "assets/photos/Alitas-de-Pollo.png"
         },
         {
           "name": {
@@ -368,7 +378,8 @@
             "es": "Tortillas rellenas de queso y vegetales salteados.",
             "en": "Tortillas stuffed with cheese and sautéed veggies."
           },
-          "price": "₡3.200"
+          "price": "₡3.200",
+          "image": "assets/photos/Quesadillas-a-la-Plancha.png"
         }
       ]
     },
@@ -387,7 +398,14 @@
             "es": "De cerdo en salsa BBQ con arroz y ensalada.",
             "en": "Pork ribs in BBQ sauce with rice and salad."
           },
-          "price": "₡5.850"
+          "price": "₡5.850",
+          "image": "assets/photos/Costillas-BBQ.png",
+          "imageSet": [
+            {
+              "src": "assets/photos/Costillas-BBQ.jpg",
+              "descriptor": "2x"
+            }
+          ]
         },
         {
           "name": {
@@ -465,7 +483,8 @@
             "es": "Lomito recubierto con tocineta en salsa de vino.",
             "en": "Tenderloin wrapped in bacon with wine sauce."
           },
-          "price": "₡7.150"
+          "price": "₡7.150",
+          "image": "assets/photos/Filet-Mignon.png"
         },
         {
           "name": {
@@ -476,7 +495,8 @@
             "es": "En salsa con papa asada y ensalada.",
             "en": "In sauce with baked potato and salad."
           },
-          "price": "₡7.500"
+          "price": "₡7.500",
+          "image": "assets/photos/Medallones-de-Lomito.png"
         },
         {
           "name": {
@@ -509,7 +529,8 @@
             "es": "Pechuga de pollo con jamón, queso mozarela, puré y ensalada.",
             "en": "Chicken breast with ham, mozzarella, mash, and salad."
           },
-          "price": "₡5.650"
+          "price": "₡5.650",
+          "image": "assets/photos/Cordon-Bleu.png"
         }
       ]
     },
@@ -671,7 +692,7 @@
             "en": "Choice of flavors."
           },
           "price": "₡2.300",
-          "image": "assets/photos/bebidas-cocteles.png"
+          "image": "assets/photos/Batidos-en-Leche.png"
         },
         {
           "name": {

--- a/menu.html
+++ b/menu.html
@@ -44,6 +44,7 @@
           "alternateName": "Mixed Fajitas",
           "description": "Acompañadas con papas y ensalada.",
           "disambiguatingDescription": "Served with fries and salad.",
+          "image": "assets/photos/Fajitas-Mixtas.png",
           "offers": {
             "@type": "Offer",
             "price": "4800",
@@ -70,6 +71,7 @@
           "alternateName": "Chicken Nuggets",
           "description": "Acompañadas con papas y ensalada.",
           "disambiguatingDescription": "Served with fries and salad.",
+          "image": "assets/photos/Nuggets-de-Pollo.png",
           "offers": {
             "@type": "Offer",
             "price": "3700",
@@ -96,6 +98,7 @@
           "alternateName": "Fish Ceviche",
           "description": "Preparado fresco del día.",
           "disambiguatingDescription": "Prepared fresh each day.",
+          "image": "assets/photos/Ceviche-de-Pescado.png",
           "offers": {
             "@type": "Offer",
             "price": "3000",
@@ -162,6 +165,7 @@
           "alternateName": "Chickpeas / White Beans / Pozol",
           "description": "Porción casera del día.",
           "disambiguatingDescription": "Homestyle portion of the day.",
+          "image": "assets/photos/Pozol.png",
           "offers": {
             "@type": "Offer",
             "price": "2000",
@@ -175,6 +179,7 @@
           "alternateName": "Cannelloni",
           "description": "2 unidades bañadas en salsa de tomate.",
           "disambiguatingDescription": "Two pieces covered in tomato sauce.",
+          "image": "assets/photos/Canelones.png",
           "offers": {
             "@type": "Offer",
             "price": "1200",
@@ -262,6 +267,7 @@
           "alternateName": "Shrimp Rice",
           "description": "Acompañado de papas y ensalada.",
           "disambiguatingDescription": "Served with fries and salad.",
+          "image": "assets/photos/Arroz-con-Camarones.png",
           "offers": {
             "@type": "Offer",
             "price": "4520",
@@ -308,6 +314,7 @@
           "alternateName": "Crispy Pork Bites",
           "description": "Porción crujiente de la casa.",
           "disambiguatingDescription": "House crispy pork portion.",
+          "image": "assets/photos/Chicharrones.png",
           "offers": {
             "@type": "Offer",
             "price": "4000",
@@ -412,6 +419,7 @@
           "alternateName": "Chicken Wings (4 pieces)",
           "description": "Salsa a elegir, acompañadas de papas.",
           "disambiguatingDescription": "Your choice of sauce, served with fries.",
+          "image": "assets/photos/Alitas-de-Pollo.png",
           "offers": {
             "@type": "Offer",
             "price": "5000",
@@ -425,6 +433,7 @@
           "alternateName": "Chicken Wings (6 pieces)",
           "description": "Salsa a elegir, acompañadas de papas.",
           "disambiguatingDescription": "Your choice of sauce, served with fries.",
+          "image": "assets/photos/Alitas-de-Pollo.png",
           "offers": {
             "@type": "Offer",
             "price": "7000",
@@ -438,6 +447,7 @@
           "alternateName": "Chicken Wings (8 pieces)",
           "description": "Salsa a elegir, acompañadas de papas.",
           "disambiguatingDescription": "Your choice of sauce, served with fries.",
+          "image": "assets/photos/Alitas-de-Pollo.png",
           "offers": {
             "@type": "Offer",
             "price": "9000",
@@ -451,6 +461,7 @@
           "alternateName": "Griddled Quesadillas",
           "description": "Tortillas rellenas de queso y vegetales salteados.",
           "disambiguatingDescription": "Tortillas stuffed with cheese and sautéed veggies.",
+          "image": "assets/photos/Quesadillas-a-la-Plancha.png",
           "offers": {
             "@type": "Offer",
             "price": "3200",
@@ -471,6 +482,7 @@
           "alternateName": "BBQ Ribs",
           "description": "De cerdo en salsa BBQ con arroz y ensalada.",
           "disambiguatingDescription": "Pork ribs in BBQ sauce with rice and salad.",
+          "image": "assets/photos/Costillas-BBQ.png",
           "offers": {
             "@type": "Offer",
             "price": "5850",
@@ -563,6 +575,7 @@
           "alternateName": "Filet Mignon",
           "description": "Lomito recubierto con tocineta en salsa de vino.",
           "disambiguatingDescription": "Tenderloin wrapped in bacon with wine sauce.",
+          "image": "assets/photos/Filet-Mignon.png",
           "offers": {
             "@type": "Offer",
             "price": "7150",
@@ -576,6 +589,7 @@
           "alternateName": "Tenderloin Medallions",
           "description": "En salsa con papa asada y ensalada.",
           "disambiguatingDescription": "In sauce with baked potato and salad.",
+          "image": "assets/photos/Medallones-de-Lomito.png",
           "offers": {
             "@type": "Offer",
             "price": "7500",
@@ -614,6 +628,7 @@
           "alternateName": "Cordon Bleu",
           "description": "Pechuga de pollo con jamón, queso mozarela, puré y ensalada.",
           "disambiguatingDescription": "Chicken breast with ham, mozzarella, mash, and salad.",
+          "image": "assets/photos/Cordon-Bleu.png",
           "offers": {
             "@type": "Offer",
             "price": "5650",
@@ -795,7 +810,7 @@
           "alternateName": "Milk Shakes",
           "description": "Sabores a elección.",
           "disambiguatingDescription": "Choice of flavors.",
-          "image": "assets/photos/bebidas-cocteles.png",
+          "image": "assets/photos/Batidos-en-Leche.png",
           "offers": {
             "@type": "Offer",
             "price": "2300",
@@ -833,7 +848,7 @@
       "alternateName": "Drinks"
     }
   ],
-  "dateModified": "2025-10-31T00:57:28.499Z"
+  "dateModified": "2025-10-31T03:45:38.000Z"
 }
 </script>
 </head>
@@ -889,7 +904,10 @@
         </button>
       </h2>
       <div class="menu-section__content" id="menu-section-content-gustitos" aria-hidden="false">
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Fajitas-Mixtas.png" alt="Fajitas Mixtas" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Fajitas Mixtas</span>
@@ -913,7 +931,10 @@
             <p class="dish-description dish-description--alt">Served with fries and salad.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Nuggets-de-Pollo.png" alt="Nuggets de Pollo" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Nuggets de Pollo</span>
@@ -937,7 +958,10 @@
             <p class="dish-description dish-description--alt">Served with fries and salad.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Ceviche-de-Pescado.png" alt="Ceviche de Pescado" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Ceviche de Pescado</span>
@@ -963,7 +987,7 @@
         </article>
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/gustitos-sopa-azteca.png" alt="Sopa Azteca" loading="lazy"/>
+            <img src="assets/photos/gustitos-sopa-azteca.png" alt="Sopa Azteca" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1000,7 +1024,10 @@
             <p class="dish-description dish-description--alt">Served with rice.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Pozol.png" alt="Garbanzos / Frijoles Blancos / Pozol" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Garbanzos / Frijoles Blancos / Pozol</span>
@@ -1012,7 +1039,10 @@
             <p class="dish-description dish-description--alt">Homestyle portion of the day.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Canelones.png" alt="Canelones" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Canelones</span>
@@ -1053,7 +1083,7 @@
       <div class="menu-section__content" id="menu-section-content-con-arroz" aria-hidden="false">
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/con-arroz-casados.png" alt="Casados" loading="lazy"/>
+            <img src="assets/photos/con-arroz-casados.png" alt="Casados" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1080,7 +1110,7 @@
         </article>
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/con-arroz-arroz-de-la-casa.png" alt="Arroz de la Casa" loading="lazy"/>
+            <img src="assets/photos/con-arroz-arroz-de-la-casa.png" alt="Arroz de la Casa" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1105,7 +1135,10 @@
             <p class="dish-description dish-description--alt">Served with fries and salad.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Arroz-con-Camarones.png" alt="Arroz con Camarones" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Arroz con Camarones</span>
@@ -1134,7 +1167,7 @@
       <div class="menu-section__content" id="menu-section-content-antojitos" aria-hidden="false">
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/antojitos-nachos.png" alt="Nachos" loading="lazy"/>
+            <img src="assets/photos/antojitos-nachos.png" alt="Nachos" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1148,7 +1181,7 @@
         </article>
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/antojitos-chalupa.png" alt="Chalupa" loading="lazy"/>
+            <img src="assets/photos/antojitos-chalupa.png" alt="Chalupa" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1160,7 +1193,10 @@
             <p class="dish-description dish-description--alt">Beef or chicken.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Chicharrones.png" alt="Chicharrones" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Chicharrones</span>
@@ -1186,7 +1222,7 @@
         </article>
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/antojitos-hamburguesa-gereni.png" alt="Hamburguesa Gereni" loading="lazy"/>
+            <img src="assets/photos/antojitos-hamburguesa-gereni.png" alt="Hamburguesa Gereni" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1258,7 +1294,10 @@
             <p class="dish-description dish-description--alt">Served with patacones and pico de gallo.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo (4 piezas)" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Alitas de Pollo (4 piezas)</span>
@@ -1270,7 +1309,10 @@
             <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo (6 piezas)" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Alitas de Pollo (6 piezas)</span>
@@ -1282,7 +1324,10 @@
             <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo (8 piezas)" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Alitas de Pollo (8 piezas)</span>
@@ -1294,7 +1339,10 @@
             <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Quesadillas-a-la-Plancha.png" alt="Quesadillas a la Plancha" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Quesadillas a la Plancha</span>
@@ -1323,7 +1371,10 @@
         </button>
       </h2>
       <div class="menu-section__content" id="menu-section-content-especialidades" aria-hidden="false">
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Costillas-BBQ.png" alt="Costillas BBQ" loading="lazy" srcset="assets/photos/Costillas-BBQ.png 1x, assets/photos/Costillas-BBQ.jpg 2x" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Costillas BBQ</span>
@@ -1373,7 +1424,7 @@
         </article>
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/especialidades-filet-de-pollo.png" alt="Filet de Pollo" loading="lazy"/>
+            <img src="assets/photos/especialidades-filet-de-pollo.png" alt="Filet de Pollo" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1410,7 +1461,10 @@
             <p class="dish-description dish-description--alt">With rice and salad.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Filet-Mignon.png" alt="Filet Miñon" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Filet Miñon</span>
@@ -1422,7 +1476,10 @@
             <p class="dish-description dish-description--alt">Tenderloin wrapped in bacon with wine sauce.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Medallones-de-Lomito.png" alt="Medallones de Lomito" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Medallones de Lomito</span>
@@ -1457,7 +1514,10 @@
             <p class="dish-description dish-description--alt">Slices in tomato sauce with rice and salad.</p>
           </div>
         </article>
-        <article class="dish">
+        <article class="dish dish--with-image">
+          <figure class="dish-media">
+            <img src="assets/photos/Cordon-Bleu.png" alt="Gordon Bleu" loading="lazy" />
+          </figure>
           <div class="dish-content">
             <div class="dish-header">
               <span class="dish-name">Gordon Bleu</span>
@@ -1486,7 +1546,7 @@
       <div class="menu-section__content" id="menu-section-content-para-el-cafe" aria-hidden="false">
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/para-el-cafe-club-sandwich.png" alt="Club Sandwich" loading="lazy"/>
+            <img src="assets/photos/para-el-cafe-club-sandwich.png" alt="Club Sandwich" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1597,7 +1657,7 @@
       <div class="menu-section__content" id="menu-section-content-bebidas" aria-hidden="false">
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/bebidas-cafe.png" alt="Café" loading="lazy"/>
+            <img src="assets/photos/bebidas-cafe.png" alt="Café" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
@@ -1647,7 +1707,7 @@
         </article>
         <article class="dish dish--with-image">
           <figure class="dish-media">
-            <img src="assets/photos/bebidas-cocteles.png" alt="Batidos en Leche" loading="lazy"/>
+            <img src="assets/photos/Batidos-en-Leche.png" alt="Batidos en Leche" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">

--- a/scripts/loadMenu.js
+++ b/scripts/loadMenu.js
@@ -141,6 +141,55 @@
     return texts.some(text => normalizeForSearch(text).includes(normalizedQuery));
   }
 
+  function resolveImageSrcset(item) {
+    if (!item || typeof item !== 'object') {
+      return '';
+    }
+
+    const base = typeof item.image === 'string' ? item.image.trim() : '';
+    const imageSet = Array.isArray(item.imageSet) ? item.imageSet : [];
+
+    const seen = new Set();
+    const sources = [];
+
+    for (const entry of imageSet) {
+      let src = '';
+      let descriptor = '';
+
+      if (typeof entry === 'string') {
+        src = entry.trim();
+      } else if (entry && typeof entry === 'object') {
+        if (typeof entry.src === 'string') {
+          src = entry.src.trim();
+        }
+        if (typeof entry.descriptor === 'string') {
+          descriptor = entry.descriptor.trim();
+        }
+      }
+
+      if (!src) {
+        continue;
+      }
+
+      if (seen.has(src)) {
+        continue;
+      }
+
+      seen.add(src);
+      sources.push(descriptor ? `${src} ${descriptor}` : src);
+    }
+
+    if (sources.length === 0) {
+      return '';
+    }
+
+    if (base && !seen.has(base)) {
+      sources.unshift(`${base} 1x`);
+    }
+
+    return sources.join(', ');
+  }
+
   function getRenderableSections(data, query) {
     const sections = data && Array.isArray(data.sections) ? data.sections : [];
     if (sections.length === 0) {
@@ -474,6 +523,10 @@
       img.src = item.image;
       img.alt = resolveText(item.name, primaryLang) || resolveText(item.name, secondaryLang) || '';
       img.loading = 'lazy';
+      const srcset = resolveImageSrcset(item);
+      if (srcset) {
+        img.srcset = srcset;
+      }
 
       media.appendChild(img);
       dish.classList.add('dish--with-image');

--- a/tools/build-static-menu.js
+++ b/tools/build-static-menu.js
@@ -60,6 +60,51 @@ function sanitizePriceForSchema(price) {
   return digits.length > 0 ? digits : null;
 }
 
+function buildImageSrcset(item) {
+  if (!item || typeof item !== 'object') {
+    return '';
+  }
+
+  const base = typeof item.image === 'string' ? item.image.trim() : '';
+  const imageSet = Array.isArray(item.imageSet) ? item.imageSet : [];
+
+  const seen = new Set();
+  const sources = [];
+
+  for (const entry of imageSet) {
+    let src = '';
+    let descriptor = '';
+
+    if (typeof entry === 'string') {
+      src = entry.trim();
+    } else if (entry && typeof entry === 'object') {
+      if (typeof entry.src === 'string') {
+        src = entry.src.trim();
+      }
+      if (typeof entry.descriptor === 'string') {
+        descriptor = entry.descriptor.trim();
+      }
+    }
+
+    if (!src || seen.has(src)) {
+      continue;
+    }
+
+    seen.add(src);
+    sources.push(descriptor ? `${src} ${descriptor}` : src);
+  }
+
+  if (sources.length === 0) {
+    return '';
+  }
+
+  if (base && !seen.has(base)) {
+    sources.unshift(`${base} 1x`);
+  }
+
+  return sources.map(source => escapeHtml(source)).join(', ');
+}
+
 function buildMenuItemSchema(item) {
   if (!item || typeof item !== 'object') {
     return null;
@@ -201,6 +246,7 @@ function renderDish(item, primaryLang, secondaryLang, indentLevel = 3) {
   const price = typeof item.price === 'string' ? item.price : '';
   const hasPrice = price.trim().length > 0;
   const image = item.image || '';
+  const imageSrcset = buildImageSrcset(item);
 
   const lines = [];
   const displayName = namePrimary || nameSecondary;
@@ -212,7 +258,15 @@ function renderDish(item, primaryLang, secondaryLang, indentLevel = 3) {
   lines.push(indent(indentLevel, `<article class="${classes.join(' ')}">`));
   if (image) {
     lines.push(indent(indentLevel + 1, '<figure class="dish-media">'));
-    lines.push(indent(indentLevel + 2, `<img src="${escapeHtml(image)}" alt="${escapeHtml(displayName)}" loading="lazy"/>`));
+    const imgAttributes = [
+      `src="${escapeHtml(image)}"`,
+      `alt="${escapeHtml(displayName)}"`,
+      'loading="lazy"'
+    ];
+    if (imageSrcset) {
+      imgAttributes.push(`srcset="${imageSrcset}"`);
+    }
+    lines.push(indent(indentLevel + 2, `<img ${imgAttributes.join(' ')} />`));
     lines.push(indent(indentLevel + 1, '</figure>'));
   }
   lines.push(indent(indentLevel + 1, '<div class="dish-content">'));

--- a/tools/check-menu-render.js
+++ b/tools/check-menu-render.js
@@ -106,8 +106,26 @@ async function main() {
         : (itemNames.en && itemNames.en.trim()) ? itemNames.en.trim()
         : 'Platillo sin nombre';
 
+      const context = `data/menu.json → ${displayTitle} → ${displayName}`;
+
       if (typeof item?.image === 'string' && item.image.trim()) {
-        trackImage(item.image, `data/menu.json → ${displayTitle} → ${displayName}`);
+        trackImage(item.image, context);
+      }
+
+      if (Array.isArray(item?.imageSet)) {
+        for (const entry of item.imageSet) {
+          let src = '';
+
+          if (typeof entry === 'string') {
+            src = entry.trim();
+          } else if (entry && typeof entry === 'object' && typeof entry.src === 'string') {
+            src = entry.src.trim();
+          }
+
+          if (src) {
+            trackImage(src, `${context} (srcset)`);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- reference the remaining photo assets from their corresponding menu entries
- support optional srcset data when rendering dishes so the ribs photo can use a high-resolution source
- rebuild the static menu fallback to include the new imagery

## Testing
- npm run check:menu

------
https://chatgpt.com/codex/tasks/task_e_69042eb1039c83239ef9ff9a9d0b6367