### PR TITLE
Fix PDF export duplication by hiding live menu

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1507,6 +1507,7 @@ body.menu-page > footer {
   width:100%;
 }
 
+body.pdf-mode .menu-container,
 body.pdf-mode .menu-columns {
   display:none;
 }

--- a/styles/print.css
+++ b/styles/print.css
@@ -34,6 +34,7 @@
   .menu-empty {
     display: none !important;
   }
+  body.pdf-mode .menu-container,
   body.pdf-mode .menu-columns {
     display: none !important;
   }


### PR DESCRIPTION
## Summary
- hide the interactive menu container whenever pdf mode is active to avoid duplicating content in exports

## Testing
- npm run check:menu

------
https://chatgpt.com/codex/tasks/task_e_690430b37a7c8323bab63cb741b32810