### PR TITLE
Add explicit dimensions to header logo image

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
    </button>
    </div>
   </div>
-<img alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-en="Gereni Bar &amp; Restaurant logo" data-i18n-es="Logo de Gereni Bar y Restaurante" src="assets/logo-gereni-bar-restaurant.png"/>
+<img alt="Logo de Gereni Bar y Restaurante" class="logo" data-i18n-attr="alt" data-i18n-en="Gereni Bar &amp; Restaurant logo" data-i18n-es="Logo de Gereni Bar y Restaurante" decoding="async" height="188" src="assets/logo-gereni-bar-restaurant.png" width="388"/>
 </header>
 <main>
  <div class="home-hero">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1033,6 +1033,7 @@ body.inicio header::after {
   max-width:200px;
   margin:0 auto;
   display:block;
+  height:auto;
   filter:drop-shadow(0 4px 8px rgba(91,58,41,0.18));
 }
 


### PR DESCRIPTION
## Summary
- add intrinsic width and height attributes to the header logo image so layout space is reserved while it loads
- keep the logo CSS using auto height to respect the intrinsic aspect ratio when scaling

## Testing
- not run (Lighthouse CLS verification requires Chrome DevTools, which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6904371ac7f08323a1a313a9286aa21b