### PR TITLE
Embed PDF header branding into first menu page

### DIFF
--- a/scripts/pdfLayout.js
+++ b/scripts/pdfLayout.js
@@ -183,6 +183,13 @@
     const root = ensureRoot(container);
     root.innerHTML = '';
 
+    const originalHeader = document.querySelector('header');
+    const clonedHeader = originalHeader ? originalHeader.cloneNode(true) : null;
+    if (clonedHeader) {
+      clonedHeader.classList.add('pdf-page__header');
+      clonedHeader.setAttribute('aria-hidden', 'true');
+    }
+
     const normalizedOptions = {
       pageWidth: options.pageWidth || `${DEFAULT_PAGE_WIDTH_IN}in`,
       pageHeight: options.pageHeight || `${DEFAULT_PAGE_HEIGHT_IN}in`,
@@ -221,6 +228,14 @@
 
     // Clean root and append pages with optional highlight decoration.
     root.innerHTML = '';
+    if (clonedHeader && pages.length > 0) {
+      const firstPage = pages[0];
+      const target = firstPage?.content;
+      if (target) {
+        target.insertBefore(clonedHeader, target.firstChild);
+      }
+    }
+
     pages.forEach(page => {
       if (page.sections.length === 1) {
         applyHighlight(page, page.sections[0].slug, normalizedOptions);

--- a/styles/main.css
+++ b/styles/main.css
@@ -1581,6 +1581,38 @@ body.pdf-mode .pdf-document {
   page-break-after:auto;
 }
 
+.pdf-page__header {
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  gap:clamp(0.35rem, 1.2vw, 0.65rem);
+  text-align:center;
+  padding-bottom:clamp(0.45rem, 1.5vw, 0.85rem);
+  margin-bottom:clamp(0.55rem, 1.8vw, 1.1rem);
+  border-bottom:1px solid rgba(91,58,41,0.16);
+  color:var(--gereni-brown);
+  pointer-events:none;
+}
+
+.pdf-page__header .logo {
+  width:min(100%, 3.9in);
+  height:auto;
+  filter:drop-shadow(0 12px 28px rgba(91,58,41,0.18));
+}
+
+.pdf-page__header .preference-controls,
+.pdf-page__header .preference-button,
+.pdf-page__header .flag-badge {
+  display:none !important;
+}
+
+.pdf-page__header h1,
+.pdf-page__header p {
+  margin:0;
+  color:inherit;
+}
+
 .pdf-page__content {
   display:flex;
   flex-direction:column;

--- a/styles/print.css
+++ b/styles/print.css
@@ -1,9 +1,16 @@
 @media print {
-  body {
+  body { 
     background: white;
     color: black;
     font-size: 11pt;
     line-height: 1.3;
+  }
+  body.pdf-mode {
+    margin: 0;
+    padding: 0 !important;
+  }
+  body.pdf-mode > header {
+    display: none !important;
   }
   header {
     background: transparent;


### PR DESCRIPTION
## Summary
- clone the existing site header into the first generated PDF page so the card layout includes the branding
- style the embedded PDF header to center the logo and hide interactive controls while using the existing color palette
- adjust print rules to remove extra body padding in PDF mode and hide the original header during export

## Testing
- ⚠️ `npm run export:menu` *(fails: Puppeteer missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_690442109d8c8323805d0ae93d0ba794