### PR TITLE
Handle continued menu sections in PDF export

### DIFF
--- a/scripts/pdfLayout.js
+++ b/scripts/pdfLayout.js
@@ -7,6 +7,7 @@
 
   const DEFAULT_PAGE_HEIGHT_IN = 10.75;
   const DEFAULT_PAGE_WIDTH_IN = 8.5;
+  const HEIGHT_TOLERANCE_PX = 2;
 
   function slugify(value) {
     if (!value) {
@@ -122,6 +123,109 @@
     return fallbacks.slice(0, 3);
   }
 
+  function resolveLocale(options = {}) {
+    const container = getContainer();
+    const renderedLang = container ? container.getAttribute('data-rendered-lang') : null;
+    const locale = options.expectedLang || renderedLang || 'es';
+    return locale.toLowerCase();
+  }
+
+  function continuationLabelText(locale) {
+    return locale.startsWith('en') ? 'Continued' : 'Continúa';
+  }
+
+  function ensureContinuationLabel(section, locale) {
+    if (!section) {
+      return;
+    }
+    const content = section.querySelector('.menu-section__content');
+    if (!content) {
+      return;
+    }
+    let label = content.querySelector('.pdf-section-continued-label');
+    if (!label) {
+      label = document.createElement('p');
+      label.classList.add('pdf-section-continued-label');
+    }
+    label.textContent = continuationLabelText(locale);
+    content.insertBefore(label, content.firstChild);
+  }
+
+  function cleanupContinuationAttributes(section) {
+    if (!section) {
+      return;
+    }
+    section.removeAttribute('id');
+    section.setAttribute('data-pdf-continued', 'true');
+    const toggle = section.querySelector('.menu-section__toggle');
+    if (toggle) {
+      toggle.removeAttribute('aria-controls');
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+    const content = section.querySelector('.menu-section__content');
+    if (content) {
+      content.removeAttribute('id');
+      content.setAttribute('aria-hidden', 'false');
+    }
+  }
+
+  function splitSectionToFit(page, section, maxContentHeight, options) {
+    const locale = resolveLocale(options);
+    const content = section.querySelector('.menu-section__content');
+    if (!content) {
+      return { fitted: null, remainder: null };
+    }
+    const dishes = Array.from(content.querySelectorAll('.dish'));
+    if (dishes.length <= 1) {
+      return { fitted: null, remainder: null };
+    }
+
+    const continuation = section.cloneNode(true);
+    const continuationContent = continuation.querySelector('.menu-section__content');
+    if (continuationContent) {
+      Array.from(continuationContent.querySelectorAll('.dish')).forEach(node => node.remove());
+    }
+
+    const moved = [];
+    let fits = false;
+
+    while (content.querySelectorAll('.dish').length > 1) {
+      const lastDish = content.querySelector('.dish:last-of-type');
+      if (!lastDish) {
+        break;
+      }
+      moved.push(lastDish);
+      continuationContent?.insertBefore(lastDish, continuationContent.firstChild);
+      page.content.appendChild(section);
+      const height = page.content.scrollHeight;
+      if (height <= maxContentHeight + HEIGHT_TOLERANCE_PX) {
+        fits = true;
+        break;
+      }
+      page.content.removeChild(section);
+    }
+
+    if (!fits) {
+      moved.reverse().forEach(node => {
+        content.appendChild(node);
+      });
+      return { fitted: null, remainder: null };
+    }
+
+    if (continuationContent && continuationContent.children.length > 0) {
+      cleanupContinuationAttributes(section);
+      cleanupContinuationAttributes(continuation);
+      ensureContinuationLabel(continuation, locale);
+      const slug = section.getAttribute('data-pdf-slug');
+      if (slug) {
+        continuation.setAttribute('data-pdf-slug', slug);
+      }
+      return { fitted: section, remainder: continuation };
+    }
+
+    return { fitted: section, remainder: null };
+  }
+
   function createHighlight(photos) {
     if (!photos || photos.length === 0) {
       return null;
@@ -211,19 +315,51 @@
 
     pages.push(current);
 
-    sections.forEach(({ slug, clone }, index) => {
+    sections.forEach(({ slug, clone }) => {
       clone.setAttribute('data-pdf-slug', slug);
-      current.content.appendChild(clone);
-      const contentHeight = current.content.scrollHeight;
-      const shouldMoveToNext = contentHeight > maxContentHeight + 2 && current.content.children.length > 1;
-      if (shouldMoveToNext) {
-        current.content.removeChild(clone);
-        current = createPageShell();
-        applyDimensions(current);
-        pages.push(current);
-        current.content.appendChild(clone);
+      let pending = clone;
+      let targetPage = current;
+
+      while (pending) {
+        targetPage.content.appendChild(pending);
+        const contentHeight = targetPage.content.scrollHeight;
+        const isOverflowing = contentHeight > maxContentHeight + HEIGHT_TOLERANCE_PX && targetPage.content.children.length > 1;
+
+        if (!isOverflowing) {
+          targetPage.sections.push({ slug });
+          pending = null;
+          current = targetPage;
+          break;
+        }
+
+        targetPage.content.removeChild(pending);
+        const { fitted, remainder } = splitSectionToFit(targetPage, pending, maxContentHeight, normalizedOptions);
+
+        if (fitted) {
+          targetPage.sections.push({ slug });
+        }
+
+        if (remainder) {
+          const nextPage = createPageShell();
+          applyDimensions(nextPage);
+          pages.push(nextPage);
+          targetPage = nextPage;
+          pending = remainder;
+          continue;
+        }
+
+        if (!fitted) {
+          const nextPage = createPageShell();
+          applyDimensions(nextPage);
+          pages.push(nextPage);
+          targetPage = nextPage;
+          // pending remains the same section to retry on the new page
+          continue;
+        }
+
+        pending = null;
+        current = targetPage;
       }
-      current.sections.push({ slug });
     });
 
     // Clean root and append pages with optional highlight decoration.

--- a/styles/main.css
+++ b/styles/main.css
@@ -1638,6 +1638,23 @@ body.pdf-mode .pdf-document {
   padding-top:clamp(0.55rem, 1.4vw, 1rem);
 }
 
+.pdf-page__content .menu-section[data-pdf-continued] {
+  border-top:1px dashed rgba(91,58,41,0.18);
+  padding-top:clamp(0.35rem, 1vw, 0.65rem);
+}
+
+.pdf-page__content .menu-section[data-pdf-continued] .menu-section__toggle {
+  padding-bottom:0.5rem;
+}
+
+.pdf-page__content .pdf-section-continued-label {
+  font-size:0.72rem;
+  letter-spacing:0.12em;
+  text-transform:uppercase;
+  color:var(--gereni-muted);
+  margin:0 0 0.3rem;
+}
+
 .pdf-page .menu-section__toggle {
   border-bottom:1px solid rgba(91,58,41,0.18);
   cursor:default;

--- a/styles/print.css
+++ b/styles/print.css
@@ -57,6 +57,17 @@
     min-height: auto;
     padding: 0.5in 0.45in 0.6in;
   }
+  body.pdf-mode .pdf-page__content .menu-section[data-pdf-continued] {
+    border-top: 0.5pt dashed rgba(91, 58, 41, 0.35);
+    padding-top: 0.3rem;
+  }
+  body.pdf-mode .pdf-section-continued-label {
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #5b3a29;
+    margin: 0 0 0.2rem;
+  }
   body.pdf-mode .pdf-highlight__figure {
     box-shadow: none;
   }


### PR DESCRIPTION
## Summary
- split overflowing menu sections across pages in the PDF layout while flagging continuation fragments
- add localized continuation labels and adjust layout logic to keep pages within the content height limit
- style continued sections for on-screen PDF preview and print outputs

## Testing
- npm run export:menu *(fails: puppeteer is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6904443b9db483239bdcacbe0f52e681