### PR TITLE
Adjust El Rancho background opacity

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -116,6 +116,7 @@ body.inicio::before {
   background-repeat:no-repeat;
   background-blend-mode:var(--home-background-blend-mode);
   transform: translateZ(0);
+  opacity:0.8;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- reduce the El Rancho hero background opacity to 80% so the image remains subtly visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69044572ba288323a638c8e893867378