### PR TITLE
Add featured dish styling and metadata

### DIFF
--- a/data/menu.json
+++ b/data/menu.json
@@ -63,7 +63,12 @@
             "en": "Prepared fresh each day."
           },
           "price": "₡3.000",
-          "image": "assets/photos/Ceviche-de-Pescado.png"
+          "image": "assets/photos/Ceviche-de-Pescado.png",
+          "featured": true,
+          "featureNote": {
+            "es": "Favorito de la casa",
+            "en": "House favorite"
+          }
         },
         {
           "name": {
@@ -186,7 +191,12 @@
             "en": "Pork, chicken, shrimp, chorizo, salad, and fries."
           },
           "price": "₡4.750",
-          "image": "assets/photos/con-arroz-arroz-de-la-casa.png"
+          "image": "assets/photos/con-arroz-arroz-de-la-casa.png",
+          "featured": true,
+          "featureNote": {
+            "es": "Receta insignia con mariscos frescos",
+            "en": "Signature recipe with fresh seafood"
+          }
         },
         {
           "name": {
@@ -276,7 +286,12 @@
             "en": "Egg patty, bacon, beef, caramelized onion, ham, and cheese."
           },
           "price": "₡4.200",
-          "image": "assets/photos/antojitos-hamburguesa-gereni.png"
+          "image": "assets/photos/antojitos-hamburguesa-gereni.png",
+          "featured": true,
+          "featureNote": {
+            "es": "Capas generosas al estilo rancho",
+            "en": "Stacked ranch-style indulgence"
+          }
         },
         {
           "name": {
@@ -501,7 +516,12 @@
             "es": "Acompañado de papa asada y ensalada.",
             "en": "Served with baked potato and salad."
           },
-          "price": "₡13.000"
+          "price": "₡13.000",
+          "featured": true,
+          "featureNote": {
+            "es": "Corte premium para compartir",
+            "en": "Premium steak built for sharing"
+          }
         },
         {
           "name": {
@@ -544,7 +564,12 @@
             "en": "Layers of bread, chicken, and vegetables."
           },
           "price": "₡4.200",
-          "image": "assets/photos/para-el-cafe-club-sandwich.png"
+          "image": "assets/photos/para-el-cafe-club-sandwich.png",
+          "featured": true,
+          "featureNote": {
+            "es": "Tres capas crujientes perfectas",
+            "en": "Three crisp layers made to share"
+          }
         },
         {
           "name": {
@@ -708,7 +733,12 @@
             "es": "Refrescante mezcla con hierbabuena fresca.",
             "en": "Refreshing blend with fresh mint."
           },
-          "price": "₡1.800"
+          "price": "₡1.800",
+          "featured": true,
+          "featureNote": {
+            "es": "Refresco estrella con hierbabuena",
+            "en": "Star refresher with garden mint"
+          }
         }
       ]
     }

--- a/scripts/loadMenu.js
+++ b/scripts/loadMenu.js
@@ -24,6 +24,11 @@
     en: 'The menu could not be loaded right now.'
   };
 
+  const featuredBadgeLabels = {
+    es: 'Destacado',
+    en: 'Featured'
+  };
+
   const SEARCH_STORAGE_KEY = 'gereni-menu-search';
 
   const schemaConfig = {
@@ -57,6 +62,69 @@
       return '';
     }
     return entry[lang] || entry.es || entry.en || '';
+  }
+
+  function resolveFeaturedBadgeLabel(primaryLang, secondaryLang) {
+    if (featuredBadgeLabels[primaryLang]) {
+      return featuredBadgeLabels[primaryLang];
+    }
+    if (secondaryLang && featuredBadgeLabels[secondaryLang]) {
+      return featuredBadgeLabels[secondaryLang];
+    }
+    return featuredBadgeLabels.es || 'Destacado';
+  }
+
+  function getExactLocalizedText(entry, lang) {
+    if (!entry || typeof entry !== 'object' || !lang) {
+      return '';
+    }
+    const value = entry[lang];
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed || '';
+    }
+    return '';
+  }
+
+  function resolvePrimaryFeatureNote(note, primaryLang, secondaryLang) {
+    if (!note) {
+      return '';
+    }
+
+    if (typeof note === 'string') {
+      return note.trim();
+    }
+
+    const primaryExact = getExactLocalizedText(note, primaryLang);
+    if (primaryExact) {
+      return primaryExact;
+    }
+
+    const secondaryExact = getExactLocalizedText(note, secondaryLang);
+    if (secondaryExact) {
+      return secondaryExact;
+    }
+
+    const fallbackExact = getExactLocalizedText(note, 'es') || getExactLocalizedText(note, 'en');
+    if (fallbackExact) {
+      return fallbackExact;
+    }
+
+    const firstString = Object.values(note).find(value => typeof value === 'string' && value.trim());
+    return firstString ? firstString.trim() : '';
+  }
+
+  function resolveAlternateFeatureNote(note, secondaryLang, primaryNote) {
+    if (!note || typeof note === 'string' || !secondaryLang) {
+      return '';
+    }
+
+    const secondaryExact = getExactLocalizedText(note, secondaryLang);
+    if (secondaryExact && secondaryExact !== primaryNote) {
+      return secondaryExact;
+    }
+
+    return '';
   }
 
   function formatUpdatedAt(dateIso, lang) {
@@ -129,6 +197,7 @@
     const texts = [];
     collectEntryTexts(item.name, texts);
     collectEntryTexts(item.description, texts);
+    collectEntryTexts(item.featureNote, texts);
 
     if (typeof item.price === 'string') {
       texts.push(item.price);
@@ -515,6 +584,11 @@
     const dish = document.createElement('article');
     dish.classList.add('dish');
 
+    const isFeatured = Boolean(item && item.featured);
+    if (isFeatured) {
+      dish.classList.add('dish--featured');
+    }
+
     if (item.image) {
       const media = document.createElement('figure');
       media.classList.add('dish-media');
@@ -535,6 +609,42 @@
 
     const textWrapper = document.createElement('div');
     textWrapper.classList.add('dish-content');
+
+    if (isFeatured) {
+      const featuredMeta = document.createElement('div');
+      featuredMeta.classList.add('dish-featured-meta');
+
+      const badgeLabel = resolveFeaturedBadgeLabel(primaryLang, secondaryLang);
+      if (badgeLabel) {
+        const badge = document.createElement('span');
+        badge.classList.add('dish-featured-badge');
+        badge.textContent = badgeLabel;
+        featuredMeta.appendChild(badge);
+      }
+
+      const primaryFeatureNote = resolvePrimaryFeatureNote(item.featureNote, primaryLang, secondaryLang);
+      if (primaryFeatureNote) {
+        const note = document.createElement('span');
+        note.classList.add('dish-featured-note');
+        note.textContent = primaryFeatureNote;
+        featuredMeta.appendChild(note);
+
+        const alternateFeatureNote = resolveAlternateFeatureNote(
+          item.featureNote,
+          secondaryLang,
+          primaryFeatureNote
+        );
+
+        if (alternateFeatureNote) {
+          const altNote = document.createElement('span');
+          altNote.classList.add('dish-featured-note', 'dish-featured-note--alt');
+          altNote.textContent = alternateFeatureNote;
+          featuredMeta.appendChild(altNote);
+        }
+      }
+
+      textWrapper.appendChild(featuredMeta);
+    }
 
     const header = document.createElement('div');
     header.classList.add('dish-header');

--- a/styles/main.css
+++ b/styles/main.css
@@ -1090,6 +1090,23 @@ body.inicio section {
   padding:0.85rem 0;
 }
 
+.menu-page .dish--featured {
+  position:relative;
+  padding:clamp(1.1rem, 2vw, 1.45rem) clamp(1rem, 2.5vw, 1.6rem);
+  margin:clamp(0.35rem, 1vw, 0.6rem) 0;
+  border-radius:26px;
+  background:linear-gradient(135deg, rgba(243,232,213,0.92), rgba(255,255,255,0.96));
+  box-shadow:0 26px 56px rgba(91,58,41,0.18);
+  border:1px solid rgba(91,58,41,0.2);
+  row-gap:clamp(0.6rem, 1.4vw, 1rem);
+}
+
+.menu-page .dish--featured.dish--with-image {
+  grid-template-columns:minmax(150px, 32%) 1fr;
+  column-gap:clamp(1.1rem, 2.5vw, 1.6rem);
+  align-items:stretch;
+}
+
 .menu-page .dish--with-image {
   grid-template-columns:120px 1fr;
   column-gap:1.1rem;
@@ -1112,11 +1129,59 @@ body.inicio section {
   background:linear-gradient(135deg, rgba(243,232,213,0.45), rgba(91,58,41,0.18));
 }
 
+.menu-page .dish--featured .dish-media {
+  border-radius:24px;
+  box-shadow:0 24px 48px rgba(91,58,41,0.26);
+  background:linear-gradient(135deg, rgba(255,214,162,0.32), rgba(91,58,41,0.18));
+}
+
 .menu-page .dish-media img {
   display:block;
   width:100%;
   height:100%;
   object-fit:cover;
+}
+
+.menu-page .dish-featured-meta {
+  display:flex;
+  align-items:center;
+  flex-wrap:wrap;
+  gap:0.45rem;
+}
+
+.menu-page .dish-featured-badge {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:0.35rem 0.9rem;
+  border-radius:999px;
+  background:var(--gereni-green);
+  color:var(--gereni-card);
+  font-weight:700;
+  font-size:0.72rem;
+  letter-spacing:0.24em;
+  text-transform:uppercase;
+  box-shadow:0 12px 24px rgba(75,106,61,0.32);
+}
+
+.menu-page .dish-featured-note {
+  font-weight:600;
+  color:var(--gereni-brown);
+  font-size:0.97rem;
+  line-height:1.35;
+  flex:1 1 220px;
+}
+
+.menu-page .dish-featured-note--alt {
+  font-weight:500;
+  color:var(--gereni-muted);
+  font-size:0.86rem;
+  font-style:italic;
+}
+
+.menu-page .dish--featured .dish-media img {
+  transform:scale(1.03);
+  transform-origin:center;
 }
 
 .menu-page .dish-content {
@@ -1125,11 +1190,20 @@ body.inicio section {
   gap:0.3rem;
 }
 
+.menu-page .dish--featured .dish-content {
+  gap:clamp(0.45rem, 1vw, 0.85rem);
+}
+
 .menu-page .dish-header {
   display:flex;
   align-items:flex-end;
   gap:0.75rem;
   width:100%;
+}
+
+.menu-page .dish--featured .dish-header {
+  align-items:baseline;
+  gap:clamp(0.85rem, 2vw, 1.4rem);
 }
 
 .menu-page .dish-name {
@@ -1140,10 +1214,20 @@ body.inicio section {
   letter-spacing:0.01em;
 }
 
+.menu-page .dish--featured .dish-name {
+  font-size:clamp(1.18rem, 2vw, 1.35rem);
+  letter-spacing:0.02em;
+}
+
 .menu-page .dish-leader {
   flex:1;
   border-bottom:1px dotted rgba(91,58,41,0.35);
   margin-bottom:0.22rem;
+}
+
+.menu-page .dish--featured .dish-leader {
+  border-bottom:1px dotted rgba(91,58,41,0.25);
+  margin-bottom:0.3rem;
 }
 
 .menu-page .dish-price {
@@ -1151,6 +1235,11 @@ body.inicio section {
   color:var(--gereni-brown);
   letter-spacing:0.08em;
   white-space:nowrap;
+}
+
+.menu-page .dish--featured .dish-price {
+  font-size:clamp(1.02rem, 1.7vw, 1.1rem);
+  letter-spacing:0.1em;
 }
 
 .menu-page .dish-name-alt {
@@ -1167,10 +1256,18 @@ body.inicio section {
   margin:0;
 }
 
+.menu-page .dish--featured .dish-description {
+  font-size:clamp(1rem, 1.6vw, 1.08rem);
+}
+
 .menu-page .dish-description--alt {
   font-style:normal;
   font-size:0.82rem;
   color:var(--gereni-muted);
+}
+
+.menu-page .dish--featured .dish-description--alt {
+  font-size:0.88rem;
 }
 
 .note {
@@ -1497,9 +1594,35 @@ body[data-theme="dark"].menu-page .dish-description--alt {
   color:rgba(234,215,192,0.72);
 }
 
+body[data-theme="dark"].menu-page .dish--featured {
+  background:linear-gradient(135deg, rgba(33,31,29,0.92), rgba(73,52,39,0.82));
+  border-color:rgba(234,215,192,0.24);
+  box-shadow:0 28px 60px rgba(0,0,0,0.5);
+}
+
+body[data-theme="dark"].menu-page .dish--featured .dish-media {
+  box-shadow:0 24px 48px rgba(0,0,0,0.6);
+  background:linear-gradient(135deg, rgba(146,176,135,0.32), rgba(33,31,29,0.88));
+}
+
 body[data-theme="dark"].menu-page .dish-media {
   box-shadow:0 18px 32px rgba(0,0,0,0.45);
   background:linear-gradient(135deg, rgba(146,176,135,0.28), rgba(34,32,30,0.82));
+}
+
+body[data-theme="dark"].menu-page .dish-featured-badge {
+  background:rgba(146,176,135,0.28);
+  color:var(--gereni-card);
+  border:1px solid rgba(234,215,192,0.24);
+  box-shadow:0 14px 28px rgba(146,176,135,0.4);
+}
+
+body[data-theme="dark"].menu-page .dish-featured-note {
+  color:var(--gereni-cream);
+}
+
+body[data-theme="dark"].menu-page .dish-featured-note--alt {
+  color:rgba(234,215,192,0.7);
 }
 
 body[data-theme="dark"] footer {

--- a/styles/print.css
+++ b/styles/print.css
@@ -101,6 +101,43 @@
     gap: 0.6rem;
     align-items: flex-start;
   }
+
+  .dish--featured {
+    border: 1pt solid #5b3a29;
+    background: rgba(243, 232, 213, 0.6);
+    padding: 0.45rem 0.35rem;
+    margin: 0.12rem 0;
+    break-inside: avoid;
+  }
+
+  .dish-featured-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 0.4rem;
+    align-items: baseline;
+    margin-bottom: 0.15rem;
+  }
+
+  .dish-featured-badge {
+    border: 0.6pt solid #5b3a29;
+    border-radius: 999px;
+    padding: 0.08rem 0.35rem;
+    font-size: 0.6rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-weight: 700;
+  }
+
+  .dish-featured-note {
+    font-size: 0.82rem;
+    font-weight: 600;
+  }
+
+  .dish-featured-note--alt {
+    font-size: 0.74rem;
+    font-style: italic;
+    font-weight: 500;
+  }
   .dish-photo {
     display: none;
   }


### PR DESCRIPTION
## Summary
- allow menu items to opt into a featured flag and optional tagline in `data/menu.json`
- update the menu loader to render featured badges/notes while keeping structured data valid
- style featured dishes on screen and in print layouts for stronger visual emphasis

## Testing
- npm run export:menu *(fails: missing libatk-1.0 on container)*

------
https://chatgpt.com/codex/tasks/task_e_690446d2a9348323877de1652a79caed