### PR TITLE
Preload menu JSON to reduce blocking requests

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="styles/print.css" media="print" />
   <link rel="manifest" href="manifest.webmanifest" />
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="preload" href="data/menu.json" as="fetch" type="application/json" />
   <script defer src="scripts/i18n.js"></script>
   <script defer src="scripts/theme.js"></script>
   <script defer src="scripts/scrollHelper.js"></script>


### PR DESCRIPTION
## Summary
- add a preload link for data/menu.json high in the menu page head to reuse the response for later fetches

## Testing
- npx lighthouse http://127.0.0.1:4173/menu.html --output=json --output-path=./lighthouse-report.json --chrome-flags="--headless" *(fails: npm 403 Forbidden to fetch lighthouse)*

------
https://chatgpt.com/codex/tasks/task_e_69044d7c616c832388b31d3993d427c7