### PR TITLE
Add preconnect hints for Google Fonts

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -9,6 +9,8 @@
   <meta property="og:image" content="https://sandgraal.github.io/gereni-menu/assets/logo-gereni-bar-restaurant.png" />
   <meta property="og:url" content="https://sandgraal.github.io/gereni-menu/menu.html" />
   <title data-i18n-es="Menú - Gereni Bar y Restaurante" data-i18n-en="Menu - Gereni Bar &amp; Restaurant">Menú - Gereni Bar y Restaurante</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Alegreya:wght@400;600;700&amp;family=Source+Sans+3:wght@400;600;700&amp;display=swap" />
   <link rel="stylesheet" href="styles/main.css" />
   <link rel="stylesheet" href="styles/print.css" media="print" />


### PR DESCRIPTION
## Summary
- add preconnect hints for Google Fonts in the menu page to reduce connection latency

## Testing
- `curl -I "https://fonts.googleapis.com/css2?family=Alegreya:wght@400;600;700&family=Source+Sans+3:wght@400;600;700&display=swap"` *(fails: CONNECT tunnel rejected with 403 in the execution environment)*
- `npx --yes lighthouse https://sandgraal.github.io/gereni-menu/menu.html --output=json --output-path=./lighthouse-report.json --quiet` *(fails: npm registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_690451baf55483239b3f961c38f4fc78