### PR TITLE
Remove duplicate scroll helper include

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -17,7 +17,6 @@
   <link rel="preload" href="data/menu.json" as="fetch" type="application/json" />
   <script defer src="scripts/i18n.js"></script>
   <script defer src="scripts/theme.js"></script>
-  <script defer src="scripts/scrollHelper.js"></script>
   <script defer src="scripts/loadMenu.js"></script>
   <script defer src="scripts/collapsibleSections.js"></script>
   <script defer src="scripts/scrollHelper.js"></script>


### PR DESCRIPTION
## Summary
- remove the duplicate scrollHelper.js script include from menu.html to keep a single reference

## Testing
- npm run test:scroll

------
https://chatgpt.com/codex/tasks/task_e_690452ef3f1083238a5023084e836139