### PR TITLE
Hide duplicate logo in PDF exports

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -1680,6 +1680,10 @@ body.menu-page > footer {
   width:100%;
 }
 
+body.pdf-mode > header {
+  display:none;
+}
+
 body.pdf-mode .menu-container,
 body.pdf-mode .menu-columns {
   display:none;


### PR DESCRIPTION
## Summary
- hide the on-page header when PDF layout is prepared so the cloned header is the only one visible

## Testing
- npm run check:all *(fails: check:social → network ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6904519dd2708323b819e406739ef6e6