### PR TITLE
Display chicken wing portions under a single menu entry

### DIFF
--- a/content/menu.md
+++ b/content/menu.md
@@ -43,9 +43,10 @@
 - **Papas Fritas | French Fries** — Orden individual de papas. | Individual order of fries. (₡2.500)
 - **Plato Surtido | Sampler Platter** — Chicharrones, chorizo, pollo, salchichón, verdura y pico de gallo. | Pork bites, chorizo, chicken, sausage, veggies, and pico de gallo. (₡8.100)
 - **Brochetas de Camarón | Shrimp Skewers** — Con patacones y pico de gallo. | Served with patacones and pico de gallo. (₡4.700)
-- **Alitas de Pollo (4 piezas) | Chicken Wings (4 pieces)** — Salsa a elegir, acompañadas de papas. | Your choice of sauce, served with fries. (₡5.000)
-- **Alitas de Pollo (6 piezas) | Chicken Wings (6 pieces)** — Salsa a elegir, acompañadas de papas. | Your choice of sauce, served with fries. (₡7.000)
-- **Alitas de Pollo (8 piezas) | Chicken Wings (8 pieces)** — Salsa a elegir, acompañadas de papas. | Your choice of sauce, served with fries. (₡9.000)
+- **Alitas de Pollo | Chicken Wings** — Salsa a elegir, acompañadas de papas. | Your choice of sauce, served with fries.
+  - 4 piezas | 4 pieces — ₡5.000
+  - 6 piezas | 6 pieces — ₡7.000
+  - 8 piezas | 8 pieces — ₡9.000
 - **Quesadillas a la Plancha | Griddled Quesadillas** — Tortillas rellenas de queso y vegetales salteados. | Tortillas stuffed with cheese and sautéed veggies. (₡3.200)
 
 ## Especialidades | Specialties

--- a/data/menu.json
+++ b/data/menu.json
@@ -335,39 +335,39 @@
         },
         {
           "name": {
-            "es": "Alitas de Pollo (4 piezas)",
-            "en": "Chicken Wings (4 pieces)"
+            "es": "Alitas de Pollo",
+            "en": "Chicken Wings"
           },
           "description": {
             "es": "Salsa a elegir, acompañadas de papas.",
             "en": "Your choice of sauce, served with fries."
           },
           "price": "₡5.000",
-          "image": "assets/photos/Alitas-de-Pollo.png"
-        },
-        {
-          "name": {
-            "es": "Alitas de Pollo (6 piezas)",
-            "en": "Chicken Wings (6 pieces)"
-          },
-          "description": {
-            "es": "Salsa a elegir, acompañadas de papas.",
-            "en": "Your choice of sauce, served with fries."
-          },
-          "price": "₡7.000",
-          "image": "assets/photos/Alitas-de-Pollo.png"
-        },
-        {
-          "name": {
-            "es": "Alitas de Pollo (8 piezas)",
-            "en": "Chicken Wings (8 pieces)"
-          },
-          "description": {
-            "es": "Salsa a elegir, acompañadas de papas.",
-            "en": "Your choice of sauce, served with fries."
-          },
-          "price": "₡9.000",
-          "image": "assets/photos/Alitas-de-Pollo.png"
+          "priceNote": "Desde ₡5.000",
+          "image": "assets/photos/Alitas-de-Pollo.png",
+          "portions": [
+            {
+              "size": {
+                "es": "4 piezas",
+                "en": "4 pieces"
+              },
+              "price": "₡5.000"
+            },
+            {
+              "size": {
+                "es": "6 piezas",
+                "en": "6 pieces"
+              },
+              "price": "₡7.000"
+            },
+            {
+              "size": {
+                "es": "8 piezas",
+                "en": "8 pieces"
+              },
+              "price": "₡9.000"
+            }
+          ]
         },
         {
           "name": {

--- a/menu.html
+++ b/menu.html
@@ -418,44 +418,40 @@
         },
         {
           "@type": "MenuItem",
-          "name": "Alitas de Pollo (4 piezas)",
-          "alternateName": "Chicken Wings (4 pieces)",
+          "name": "Alitas de Pollo",
+          "alternateName": "Chicken Wings",
           "description": "Salsa a elegir, acompañadas de papas.",
           "disambiguatingDescription": "Your choice of sauce, served with fries.",
           "image": "assets/photos/Alitas-de-Pollo.png",
           "offers": {
-            "@type": "Offer",
-            "price": "5000",
-            "priceCurrency": "CRC",
-            "availability": "https://schema.org/InStock"
-          }
-        },
-        {
-          "@type": "MenuItem",
-          "name": "Alitas de Pollo (6 piezas)",
-          "alternateName": "Chicken Wings (6 pieces)",
-          "description": "Salsa a elegir, acompañadas de papas.",
-          "disambiguatingDescription": "Your choice of sauce, served with fries.",
-          "image": "assets/photos/Alitas-de-Pollo.png",
-          "offers": {
-            "@type": "Offer",
-            "price": "7000",
-            "priceCurrency": "CRC",
-            "availability": "https://schema.org/InStock"
-          }
-        },
-        {
-          "@type": "MenuItem",
-          "name": "Alitas de Pollo (8 piezas)",
-          "alternateName": "Chicken Wings (8 pieces)",
-          "description": "Salsa a elegir, acompañadas de papas.",
-          "disambiguatingDescription": "Your choice of sauce, served with fries.",
-          "image": "assets/photos/Alitas-de-Pollo.png",
-          "offers": {
-            "@type": "Offer",
-            "price": "9000",
-            "priceCurrency": "CRC",
-            "availability": "https://schema.org/InStock"
+            "@type": "OfferCatalog",
+            "name": "Porciones",
+            "itemListElement": [
+              {
+                "@type": "Offer",
+                "name": "4 piezas",
+                "description": "4 pieces",
+                "price": "5000",
+                "priceCurrency": "CRC",
+                "availability": "https://schema.org/InStock"
+              },
+              {
+                "@type": "Offer",
+                "name": "6 piezas",
+                "description": "6 pieces",
+                "price": "7000",
+                "priceCurrency": "CRC",
+                "availability": "https://schema.org/InStock"
+              },
+              {
+                "@type": "Offer",
+                "name": "8 piezas",
+                "description": "8 pieces",
+                "price": "9000",
+                "priceCurrency": "CRC",
+                "availability": "https://schema.org/InStock"
+              }
+            ]
           }
         },
         {
@@ -1297,49 +1293,42 @@
             <p class="dish-description dish-description--alt">Served with patacones and pico de gallo.</p>
           </div>
         </article>
-        <article class="dish dish--with-image">
+        <article class="dish dish--with-image dish--wings">
           <figure class="dish-media">
-            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo (4 piezas)" loading="lazy" />
+            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo" loading="lazy" />
           </figure>
           <div class="dish-content">
             <div class="dish-header">
-              <span class="dish-name">Alitas de Pollo (4 piezas)</span>
+              <span class="dish-name">Alitas de Pollo</span>
               <span class="dish-leader" aria-hidden="true"></span>
-              <span class="dish-price">₡5.000</span>
+              <span class="dish-price">Desde ₡5.000</span>
             </div>
-            <span class="dish-name-alt">Chicken Wings (4 pieces)</span>
+            <span class="dish-name-alt">Chicken Wings</span>
             <p class="dish-description">Salsa a elegir, acompañadas de papas.</p>
             <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
-          </div>
-        </article>
-        <article class="dish dish--with-image">
-          <figure class="dish-media">
-            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo (6 piezas)" loading="lazy" />
-          </figure>
-          <div class="dish-content">
-            <div class="dish-header">
-              <span class="dish-name">Alitas de Pollo (6 piezas)</span>
-              <span class="dish-leader" aria-hidden="true"></span>
-              <span class="dish-price">₡7.000</span>
-            </div>
-            <span class="dish-name-alt">Chicken Wings (6 pieces)</span>
-            <p class="dish-description">Salsa a elegir, acompañadas de papas.</p>
-            <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
-          </div>
-        </article>
-        <article class="dish dish--with-image">
-          <figure class="dish-media">
-            <img src="assets/photos/Alitas-de-Pollo.png" alt="Alitas de Pollo (8 piezas)" loading="lazy" />
-          </figure>
-          <div class="dish-content">
-            <div class="dish-header">
-              <span class="dish-name">Alitas de Pollo (8 piezas)</span>
-              <span class="dish-leader" aria-hidden="true"></span>
-              <span class="dish-price">₡9.000</span>
-            </div>
-            <span class="dish-name-alt">Chicken Wings (8 pieces)</span>
-            <p class="dish-description">Salsa a elegir, acompañadas de papas.</p>
-            <p class="dish-description dish-description--alt">Your choice of sauce, served with fries.</p>
+            <ul class="dish-options" aria-label="Porciones disponibles">
+              <li class="dish-option">
+                <span class="dish-option-label">
+                  <span class="dish-option-primary">4 piezas</span>
+                  <span class="dish-option-secondary">4 pieces</span>
+                </span>
+                <span class="dish-option-price">₡5.000</span>
+              </li>
+              <li class="dish-option">
+                <span class="dish-option-label">
+                  <span class="dish-option-primary">6 piezas</span>
+                  <span class="dish-option-secondary">6 pieces</span>
+                </span>
+                <span class="dish-option-price">₡7.000</span>
+              </li>
+              <li class="dish-option">
+                <span class="dish-option-label">
+                  <span class="dish-option-primary">8 piezas</span>
+                  <span class="dish-option-secondary">8 pieces</span>
+                </span>
+                <span class="dish-option-price">₡9.000</span>
+              </li>
+            </ul>
           </div>
         </article>
         <article class="dish dish--with-image">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1113,6 +1113,54 @@ body.inicio section {
   align-items:start;
 }
 
+.menu-page .dish--wings {
+  grid-template-columns:clamp(190px, 24vw, 260px) 1fr;
+  column-gap:clamp(1.2rem, 2.8vw, 2rem);
+  align-items:stretch;
+}
+
+.menu-page .dish--wings .dish-media {
+  aspect-ratio:1;
+}
+
+.menu-page .dish-options {
+  margin:0.75rem 0 0;
+  padding:0;
+  list-style:none;
+  display:flex;
+  flex-direction:column;
+  gap:0.45rem;
+}
+
+.menu-page .dish-option {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:1rem;
+  padding:0.55rem 0.9rem;
+  border-radius:14px;
+  background:rgba(91,58,41,0.06);
+  box-shadow:inset 0 0 0 1px rgba(91,58,41,0.08);
+}
+
+.menu-page .dish-option-label {
+  display:flex;
+  flex-direction:column;
+  gap:0.1rem;
+  font-weight:600;
+}
+
+.menu-page .dish-option-secondary {
+  font-size:0.85rem;
+  color:rgba(91,58,41,0.7);
+  font-weight:500;
+}
+
+.menu-page .dish-option-price {
+  font-weight:700;
+  font-variant-numeric:tabular-nums;
+}
+
 .menu-page .menu-section .dish:first-of-type {
   padding-top:0;
 }
@@ -1559,6 +1607,15 @@ body[data-theme="dark"].menu-page .menu-surface::before {
 
 body[data-theme="dark"].menu-page .menu-surface::after {
   background:rgba(234,215,192,0.18);
+}
+
+body[data-theme="dark"].menu-page .dish-option {
+  background:rgba(234,215,192,0.08);
+  box-shadow:inset 0 0 0 1px rgba(234,215,192,0.16);
+}
+
+body[data-theme="dark"].menu-page .dish-option-secondary {
+  color:rgba(234,215,192,0.75);
 }
 
 body[data-theme="dark"].menu-page .menu-header__location,
@@ -2432,8 +2489,16 @@ body.pdf-mode .pdf-document {
     grid-template-columns:1fr;
   }
 
+  .menu-page .dish--wings {
+    grid-template-columns:1fr;
+  }
+
   .menu-page .dish-media {
     max-width:220px;
     justify-self:center;
+  }
+
+  .menu-page .dish-option {
+    align-items:flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- consolidate the chicken wing listing into a single entry with a larger photo and bilingual portion options
- refresh the markdown content, data JSON, and structured data to list the 4/6/8 piece prices together
- add styling for the option list with responsive and dark-theme adjustments

## Testing
- npm run check:prices
- npm run check:menu

------
https://chatgpt.com/codex/tasks/task_e_690455e4832c832389dc47d3b8b8efee