### PR TITLE
fix: unblock Generate Web Image Variants workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ ai/_state/*
 
 # AI-generated image optimization artifacts (not committed)
 assets/photos/optimized/
-public/images/


### PR DESCRIPTION
## Summary
- Investigated the Generate Web Image Variants workflow to understand why new photos were not producing committed outputs.
- Determined that `public/images` was ignored by Git, preventing the workflow from detecting and pushing generated variants.
- Updated the ignore list so responsive image artifacts can now be committed by the automation.

## Plan
1. Review the GitHub Actions workflow configuration for Generate Web Image Variants.
2. Inspect supporting scripts to confirm the expected output directory (`public/images`).
3. Check repository ignore rules for any conflicting entries.
4. Remove the conflicting ignore entry to allow generated files to be tracked.
5. Verify that `git status --short public/images` now reports new artifacts as expected.

## Changes
- `.gitignore`

## Verification
Commands:
```
(none)
```
Evidence:
- (not applicable)

## Risks & Mitigations
- Larger commits from generated assets → rely on workflow automation to keep updates scoped to generated variants.

## Follow-ups
- None


------
https://chatgpt.com/codex/tasks/task_e_69064b8f7f5083239c5e84ab624ff84b