### PR TITLE
fix: rebase process-images job before pushing

### DIFF
--- a/.github/workflows/image-processing.yml
+++ b/.github/workflows/image-processing.yml
@@ -34,7 +34,8 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add public/images
             git commit -m "chore(images): update generated assets"
-            git push
+            git pull --rebase origin main
+            git push origin HEAD:main
           else
             echo "No image updates detected."
           fi


### PR DESCRIPTION
## Summary
- ensure the process-images workflow rebases on the latest main branch before pushing
- reduce push failures caused by remote updates that land during the job run
- keep the generated image artifacts publishing step reliable

## Plan
1. Inspect the process-images workflow for the commit-and-push logic.
2. Add a rebase step so the job integrates remote commits before pushing.
3. Target the push to the main branch explicitly after rebasing.
4. Verify the workflow syntax is still valid.
5. Document the change in the PR summary.

## Changes
- .github/workflows/image-processing.yml

## Verification
Commands:
```
# CI
```
Evidence:
- Pending CI

## Risks & Mitigations
- Rebase conflicts if remote artifacts change simultaneously → Workflow will fail, signaling manual resolution is needed

## Follow-ups
- None


------
https://chatgpt.com/codex/tasks/task_e_6906518dc5e08323bcc78d2a5128c057