### PR TITLE
Add configurable home quick actions with Wi-Fi entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Permite editar precios, descripciones y fotografías fácilmente, generando auto
 | `menu.html`                      | Menú dinámico cargado desde `data/menu.json`                   |
 | `content/menu.md`                | Fuente editable (Markdown) del menú                            |
 | `data/menu.json`                 | Versión generada para la web                                   |
+| `data/home-actions.json`         | Configura las tarjetas de acciones rápidas                     |
 | `ai/scripts/`                    | Scripts automatizados (análisis, sincronización, optimización) |
 | `assets/`                        | Imágenes, íconos y logotipos                                   |
 | `tools/validate-prices.js`       | Valida formato `₡0.000`                                        |

--- a/data/home-actions.json
+++ b/data/home-actions.json
@@ -1,0 +1,50 @@
+{
+  "actions": [
+    {
+      "id": "view-menu",
+      "href": "menu.html",
+      "variant": "primary",
+      "title": {
+        "es": "Ver el Menú",
+        "en": "View the Menu"
+      },
+      "description": {
+        "es": "Descubre platillos destacados y recomendaciones del chef.",
+        "en": "See featured dishes and chef suggestions."
+      },
+      "icon": "menu"
+    },
+    {
+      "id": "download-menu",
+      "href": "output/Menu_Gereni_digital_es_dark.pdf",
+      "variant": "secondary",
+      "classes": ["link-download"],
+      "title": {
+        "es": "Descargar Menú en PDF",
+        "en": "Download Menu PDF"
+      },
+      "description": {
+        "es": "Guárdalo sin conexión o compártelo con tu mesa.",
+        "en": "Keep it offline or share it with your table."
+      },
+      "icon": "download",
+      "newTab": true
+    },
+    {
+      "id": "connect-wifi",
+      "href": "#wifi",
+      "variant": "primary",
+      "title": {
+        "es": "Conectarse al Wi-Fi",
+        "en": "Connect to Wi-Fi"
+      },
+      "description": {
+        "es": "Accede a la red del restaurante en segundos.",
+        "en": "Get online at the restaurant in seconds."
+      },
+      "icon": "wifi",
+      "newTab": true,
+      "rel": "noopener"
+    }
+  ]
+}

--- a/docs/operations/home-actions.md
+++ b/docs/operations/home-actions.md
@@ -1,0 +1,24 @@
+# Actualizar las acciones rápidas de la página de inicio
+
+Las tarjetas de "Acciones rápidas" que aparecen en `index.html` se generan automáticamente a partir del archivo [`data/home-actions.json`](../../data/home-actions.json). Esto permite que el equipo del restaurante ajuste enlaces, textos o el acceso al Wi-Fi sin editar el HTML.
+
+## Cómo editar las acciones
+
+1. Abre [`data/home-actions.json`](../../data/home-actions.json) en GitHub.
+2. Cada entrada dentro de `"actions"` representa una tarjeta. Los campos disponibles son:
+   - `id`: identificador opcional para referencia interna.
+   - `href`: URL o ancla que abrirá la tarjeta.
+   - `variant`: estilo del botón (`primary`, `secondary`, etc.).
+   - `classes`: arreglo opcional de clases CSS adicionales (por ejemplo `"link-download"`).
+   - `title` y `description`: objetos con traducciones `es` e `en`.
+   - `icon`: clave del ícono a mostrar (`menu`, `download`, `wifi`).
+   - `newTab`: define si el enlace abre en una pestaña nueva (`true`/`false`).
+   - `rel`: valor del atributo `rel` cuando se necesita (por ejemplo `"noopener"`).
+3. Guarda los cambios con un Commit o Pull Request. Al recargar la página, el script `scripts/homeActions.js` reconstruirá la lista automáticamente.
+
+> [!TIP]
+> La tarjeta de Wi-Fi puede apuntar al portal cautivo del proveedor o a un PDF con instrucciones. Solo actualiza `href` y, si aplica, `rel` para reflejar la política de seguridad de tu enlace.
+
+## Fallback sin JavaScript
+
+El HTML mantiene una copia de respaldo de las tres tarjetas principales. Si el navegador bloquea JavaScript o el JSON no está disponible, los visitantes seguirán viendo opciones funcionales.

--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
 </script>
 <script defer="" src="scripts/pdfLink.js">
 </script>
+<script defer="" src="scripts/homeActions.js">
+</script>
 <script defer="" src="scripts/swRegister.js">
 </script>
 <script type="application/ld+json">
@@ -99,7 +101,7 @@
   <div aria-hidden="true" class="home-promos" data-promos-root data-promos-state="loading">
   </div>
   <div class="home-panel" role="navigation" aria-label="Acciones rápidas" data-i18n-attr="aria-label" data-i18n-es="Acciones rápidas" data-i18n-en="Quick actions">
-   <ul class="home-actions" data-variant="primary">
+   <ul class="home-actions" data-variant="primary" data-home-actions data-home-actions-source="data/home-actions.json">
     <li class="home-actions__item">
      <a class="home-actions__link home-actions__link--primary" data-sound-id="menu-cta" href="menu.html">
       <span aria-hidden="true" class="home-actions__icon">
@@ -135,6 +137,26 @@
            </span>
        <span class="home-actions__description" data-i18n-es="Guárdalo sin conexión o compártelo con tu mesa." data-i18n-en="Keep it offline or share it with your table.">
             Guárdalo sin conexión o compártelo con tu mesa.
+           </span>
+     </span>
+    </a>
+    </li>
+    <li class="home-actions__item">
+     <a class="home-actions__link home-actions__link--primary" data-home-actions-fallback="connect-wifi" data-sound-id="menu-cta" href="#wifi" rel="noopener" target="_blank">
+      <span aria-hidden="true" class="home-actions__icon">
+       <svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
+        <path d="M5 12.5C8.7 9.5 12.3 8 16 8s7.3 1.5 11 4.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <path d="M9 17c2.1-1.7 4.1-2.5 7-2.5s4.9.8 7 2.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <path d="M13.5 21.5c.9-.7 1.8-1 2.5-1s1.6.3 2.5 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+        <circle cx="16" cy="24" fill="currentColor" r="2"/>
+       </svg>
+      </span>
+      <span class="home-actions__content">
+       <span class="home-actions__title" data-home-actions-fallback-title data-i18n-es="Conectarse al Wi-Fi" data-i18n-en="Connect to Wi-Fi">
+            Conectarse al Wi-Fi
+           </span>
+       <span class="home-actions__description" data-home-actions-fallback-description data-i18n-es="Accede a la red del restaurante en segundos." data-i18n-en="Get online at the restaurant in seconds.">
+            Accede a la red del restaurante en segundos.
            </span>
       </span>
      </a>

--- a/scripts/homeActions.js
+++ b/scripts/homeActions.js
@@ -1,0 +1,178 @@
+(function() {
+  'use strict';
+
+  const list = document.querySelector('[data-home-actions]');
+  if (!list) {
+    return;
+  }
+
+  const sourceUrl = list.getAttribute('data-home-actions-source') || 'data/home-actions.json';
+
+  function resolveActions(payload) {
+    if (!payload) {
+      return [];
+    }
+
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (Array.isArray(payload.actions)) {
+      return payload.actions;
+    }
+
+    return [];
+  }
+
+  const ICON_MARKUP = {
+    menu: '<svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">\
+<path d="M7 10H25" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<path d="M7 16H19" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<path d="M7 22H21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<rect height="20" rx="3" stroke="currentColor" stroke-width="2" width="20" x="6" y="6"/>\
+</svg>',
+    download: '<svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">\
+<path d="M16 7V21" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<path d="M11 16L16 21L21 16" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<path d="M9 24H23" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+</svg>',
+    wifi: '<svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">\
+<path d="M5 12.5C8.7 9.5 12.3 8 16 8s7.3 1.5 11 4.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<path d="M9 17c2.1-1.7 4.1-2.5 7-2.5s4.9.8 7 2.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<path d="M13.5 21.5c.9-.7 1.8-1 2.5-1s1.6.3 2.5 1" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>\
+<circle cx="16" cy="24" fill="currentColor" r="2"/>\
+</svg>'
+  };
+
+  function createIconSpan(iconKey) {
+    const span = document.createElement('span');
+    span.className = 'home-actions__icon';
+    span.setAttribute('aria-hidden', 'true');
+    const markup = ICON_MARKUP[String(iconKey).toLowerCase()];
+    if (markup) {
+      span.innerHTML = markup;
+    }
+    return span;
+  }
+
+  function createTextSpan(className, text, translations) {
+    const span = document.createElement('span');
+    span.className = className;
+    if (translations && typeof translations === 'object') {
+      if (translations.es) {
+        span.dataset.i18nEs = translations.es;
+      }
+      if (translations.en) {
+        span.dataset.i18nEn = translations.en;
+      }
+    }
+    span.textContent = (translations && (translations.es || translations.en)) || text || '';
+    return span;
+  }
+
+  function getSafeVariant(variant) {
+    const base = String(variant || '').trim();
+    if (!base) {
+      return 'primary';
+    }
+
+    if (!/^[-a-zA-Z0-9_]+$/.test(base)) {
+      return 'primary';
+    }
+
+    return base;
+  }
+
+  function applyLinkAttributes(link, action) {
+    const classes = Array.isArray(action.classes) ? action.classes : [];
+    classes.forEach(cls => {
+      if (typeof cls === 'string' && cls.trim()) {
+        link.classList.add(cls.trim());
+      }
+    });
+
+    const soundId = typeof action.soundId === 'string' ? action.soundId.trim() : 'menu-cta';
+    if (soundId) {
+      link.dataset.soundId = soundId;
+    }
+
+    if (action.newTab) {
+      link.target = '_blank';
+      if (!action.rel) {
+        link.rel = 'noopener';
+      }
+    }
+
+    if (action.rel) {
+      link.rel = String(action.rel);
+    }
+  }
+
+  function createActionItem(action) {
+    const item = document.createElement('li');
+    item.className = 'home-actions__item';
+
+    const link = document.createElement('a');
+    const variant = getSafeVariant(action.variant);
+    link.className = 'home-actions__link home-actions__link--' + variant;
+
+    const href = typeof action.href === 'string' ? action.href.trim() : '';
+    if (href) {
+      link.href = href;
+    } else {
+      link.href = '#';
+    }
+
+    if (action.id) {
+      link.dataset.homeActionId = String(action.id);
+    }
+
+    applyLinkAttributes(link, action);
+
+    link.appendChild(createIconSpan(action.icon));
+
+    const content = document.createElement('span');
+    content.className = 'home-actions__content';
+
+    content.appendChild(
+      createTextSpan('home-actions__title', '', action.title)
+    );
+
+    content.appendChild(
+      createTextSpan('home-actions__description', '', action.description)
+    );
+
+    link.appendChild(content);
+    item.appendChild(link);
+    return item;
+  }
+
+  function renderActions(actions) {
+    if (!Array.isArray(actions) || actions.length === 0) {
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    actions.forEach(action => {
+      fragment.appendChild(createActionItem(action));
+    });
+
+    list.innerHTML = '';
+    list.appendChild(fragment);
+    list.setAttribute('data-home-actions-loaded', 'true');
+  }
+
+  fetch(sourceUrl, { cache: 'no-store' })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Failed to load home actions');
+      }
+
+      return response.json();
+    })
+    .then(resolveActions)
+    .then(renderActions)
+    .catch(() => {
+      // Keep fallback markup if fetch fails
+    });
+})();


### PR DESCRIPTION
## Summary
- add a Wi-Fi quick action card to the home page alongside existing menu links
- load quick actions from a JSON manifest so restaurant staff can update them without touching HTML
- document how to manage the new configuration file for quick actions

## Plan
1. Create a JSON data source describing the desired quick actions.
2. Render the quick actions list from that source via a client-side helper.
3. Update the home page markup to expose the Wi-Fi fallback card and hook in the script.
4. Document the workflow for restaurant staff to update the quick actions.
5. Run accessibility smoke tests to confirm the list structure remains valid.

## Changes
- `index.html`
- `scripts/homeActions.js`
- `data/home-actions.json`
- `docs/operations/home-actions.md`
- `README.md`

## Verification
Commands:
```
npm run test:a11y
```
Evidence:
- Accessibility smoke tests for quick actions

## Risks & Mitigations
- JSON fetch failure → fallback markup stays in place so the quick actions remain available.

## Follow-ups
- None


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d369c23008323ba663846aa007c24)