### PR TITLE
Remove Wi-Fi card from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     </a>
     </li>
     <li class="home-actions__item">
-     <a class="home-actions__link home-actions__link--primary" data-home-actions-fallback="connect-wifi" data-sound-id="menu-cta" href="#wifi">
+     <a class="home-actions__link home-actions__link--primary" data-home-actions-fallback="connect-wifi" data-sound-id="menu-cta" href="https://wifi.gereni.local/portal" rel="noopener" target="_blank">
       <span aria-hidden="true" class="home-actions__icon">
        <svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
         <path d="M5 12.5C8.7 9.5 12.3 8 16 8s7.3 1.5 11 4.5" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
@@ -157,22 +157,11 @@
            </span>
        <span class="home-actions__description" data-home-actions-fallback-description data-i18n-es="Copia el acceso invitado sin mostrar la contraseña." data-i18n-en="Copy guest Wi-Fi access without showing the password.">
             Copia el acceso invitado sin mostrar la contraseña.
-           </span>
-      </span>
-     </a>
-    </li>
+       </span>
+     </span>
+    </a>
+   </li>
    </ul>
-  <section aria-labelledby="wifi-heading" class="wifi-card" data-wifi-section id="wifi">
-    <div class="wifi-card__header">
-      <h2 class="wifi-card__title" data-i18n-en="Restaurant Wi-Fi" data-i18n-es="Wi-Fi del restaurante" id="wifi-heading">Wi-Fi del restaurante</h2>
-      <p class="wifi-card__instructions" data-i18n-en="Copy the guest credentials securely and open the Wi-Fi portal." data-i18n-es="Copia las credenciales de invitados de forma segura y abre el portal de Wi-Fi." data-wifi-instructions>Copia las credenciales de invitados de forma segura y abre el portal de Wi-Fi.</p>
-    </div>
-    <div class="wifi-card__actions">
-      <button class="wifi-card__button" data-i18n-en="Copy Wi-Fi access" data-i18n-es="Copiar acceso a Wi-Fi" data-wifi-copy type="button" aria-describedby="wifi-feedback">Copiar acceso a Wi-Fi</button>
-      <a class="wifi-card__button wifi-card__button--secondary" data-i18n-en="Open Wi-Fi portal" data-i18n-es="Abrir portal de Wi-Fi" data-wifi-launch href="https://wifi.gereni.local/portal" rel="noopener" target="_blank">Abrir portal de Wi-Fi</a>
-    </div>
-    <p id="wifi-feedback" aria-live="polite" class="wifi-card__feedback" data-i18n-en="Wi-Fi access copied to clipboard." data-i18n-es="Acceso a Wi-Fi copiado al portapapeles." data-wifi-feedback data-wifi-feedback-error-en="We couldn't copy the Wi-Fi access. Please try again." data-wifi-feedback-error-es="No se pudo copiar el acceso a Wi-Fi. Inténtalo de nuevo." hidden>Acceso a Wi-Fi copiado al portapapeles.</p>
-  </section>
    <div class="home-social">
     <p class="home-social__title" data-i18n-es="Conéctate con nosotros" data-i18n-en="Connect with us">
         Conéctate con nosotros


### PR DESCRIPTION
## Summary
- remove the restaurant Wi-Fi details card from the home hero actions area
- repoint the Connect Wi-Fi fallback link directly to the Wi-Fi portal to keep access available
- verify home actions logic still passes automated checks

## Plan
1. Update the home actions markup to drop the Wi-Fi card section entirely.
2. Point the remaining Wi-Fi CTA to the existing portal URL and ensure semantics remain intact.
3. Run the home actions test suite to confirm nothing regresses.

## Changes
- index.html

## Verification
Commands:
```
npm run test:home-actions
```
Evidence:
- ![Updated home hero without Wi-Fi card](browser:/invocations/dwsnljhw/artifacts/artifacts/home-no-wifi-card.png)

## Risks & Mitigations
- Users lose the inline Wi-Fi credentials card → Link now opens the Wi-Fi portal in a new tab to preserve access.

## Follow-ups
- none


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e5b0d4fb48323879523f2fb2bed07)