### PR TITLE
Add holiday seasonal effects to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,8 @@
 </script>
 <script defer="" src="scripts/homeActions.js">
 </script>
+<script defer="" src="scripts/seasonalMode.js">
+</script>
 <script defer="" src="scripts/swRegister.js">
 </script>
 <script type="application/ld+json">

--- a/scripts/seasonalMode.js
+++ b/scripts/seasonalMode.js
@@ -1,0 +1,343 @@
+(function() {
+  'use strict';
+
+  const OVERRIDE_KEY = 'gereni-holiday-mode';
+  const START_BUFFER_DAYS = 1; // day after Thanksgiving
+  const SEASON_END_MONTH = 11; // December
+  const SEASON_END_DAY = 28; // turn off on Dec 28 (exclusive)
+  const LIGHT_COLORS = ['#FAD643', '#F66D44', '#5BC0EB', '#9C89B8'];
+  const MAX_SNOWFLAKES = 80;
+  const SNOW_MIN_SIZE = 1.5;
+  const SNOW_MAX_SIZE = 3.5;
+
+  function safeLocalStorage() {
+    try {
+      return window.localStorage;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function getQueryOverride() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const value = params.get('holidayMode');
+      if (value === 'on' || value === 'off') {
+        const storage = safeLocalStorage();
+        if (storage) {
+          storage.setItem(OVERRIDE_KEY, value);
+        }
+        return value;
+      }
+    } catch (error) {
+      // ignore
+    }
+    return null;
+  }
+
+  function getStoredOverride() {
+    const storage = safeLocalStorage();
+    if (!storage) return null;
+    const value = storage.getItem(OVERRIDE_KEY);
+    if (value === 'on' || value === 'off') {
+      return value;
+    }
+    return null;
+  }
+
+  function getThanksgivingDate(year) {
+    const date = new Date(Date.UTC(year, 10, 1)); // November 1 in UTC to avoid TZ drift
+    const dayOfWeek = date.getUTCDay();
+    const firstThursdayOffset = (4 - dayOfWeek + 7) % 7; // Thursday is 4
+    const thanksgivingUtc = 1 + firstThursdayOffset + 21; // fourth Thursday
+    return new Date(Date.UTC(year, 10, thanksgivingUtc));
+  }
+
+  function getSeasonWindow() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const thanksgiving = getThanksgivingDate(year);
+    const start = new Date(thanksgiving.getTime());
+    start.setUTCDate(start.getUTCDate() + START_BUFFER_DAYS);
+    const end = new Date(Date.UTC(year, SEASON_END_MONTH, SEASON_END_DAY));
+    return { start, end };
+  }
+
+  function isSeasonActive() {
+    const queryOverride = getQueryOverride();
+    if (queryOverride === 'on') return true;
+    if (queryOverride === 'off') return false;
+
+    const stored = getStoredOverride();
+    if (stored === 'on') return true;
+    if (stored === 'off') return false;
+
+    const now = new Date();
+    const { start, end } = getSeasonWindow();
+    return now >= start && now < end;
+  }
+
+  function getCurrentLanguage() {
+    try {
+      if (window.GereniLang && typeof window.GereniLang.getCurrent === 'function') {
+        return window.GereniLang.getCurrent();
+      }
+    } catch (error) {
+      // ignore
+    }
+    const lang = document.documentElement.getAttribute('lang') || 'es';
+    return lang.startsWith('en') ? 'en' : 'es';
+  }
+
+  function prefersReducedMotion() {
+    try {
+      return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function applySeasonalPalette() {
+    document.documentElement.setAttribute('data-seasonal-holiday', 'true');
+  }
+
+  function createLightString() {
+    const lights = document.createElement('div');
+    lights.className = 'holiday-lights';
+    lights.setAttribute('aria-hidden', 'true');
+
+    for (let i = 0; i < 28; i++) {
+      const bulb = document.createElement('span');
+      bulb.className = 'holiday-lights__bulb';
+      bulb.style.setProperty('--bulb-color', LIGHT_COLORS[i % LIGHT_COLORS.length]);
+      bulb.style.animationDelay = `${(i % 8) * 120}ms`;
+      lights.appendChild(bulb);
+    }
+
+    const target = document.querySelector('.home-hero') || document.body;
+    target.prepend(lights);
+  }
+
+  function createSnowLayer() {
+    if (prefersReducedMotion()) return;
+    const canvas = document.createElement('canvas');
+    canvas.className = 'holiday-snow';
+    canvas.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(canvas);
+
+    const ctx = canvas.getContext('2d');
+    const flakes = [];
+
+    function resize() {
+      canvas.width = window.innerWidth;
+      canvas.height = Math.max(window.innerHeight, document.documentElement.clientHeight || 0);
+    }
+
+    function spawnFlake() {
+      return {
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height,
+        r: Math.random() * (SNOW_MAX_SIZE - SNOW_MIN_SIZE) + SNOW_MIN_SIZE,
+        d: Math.random() * 0.6 + 0.3,
+        drift: Math.random() * 1 - 0.5
+      };
+    }
+
+    function initFlakes() {
+      flakes.length = 0;
+      for (let i = 0; i < MAX_SNOWFLAKES; i++) {
+        flakes.push(spawnFlake());
+      }
+    }
+
+    function draw() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = 'rgba(255,255,255,0.9)';
+      ctx.beginPath();
+      for (const flake of flakes) {
+        ctx.moveTo(flake.x, flake.y);
+        ctx.arc(flake.x, flake.y, flake.r, 0, Math.PI * 2, true);
+      }
+      ctx.fill();
+      update();
+      window.requestAnimationFrame(draw);
+    }
+
+    function update() {
+      for (const flake of flakes) {
+        flake.y += flake.d + flake.r * 0.06;
+        flake.x += flake.drift * 0.6;
+
+        if (flake.y > canvas.height) {
+          flake.y = -flake.r;
+          flake.x = Math.random() * canvas.width;
+        }
+        if (flake.x > canvas.width) {
+          flake.x = 0;
+        } else if (flake.x < 0) {
+          flake.x = canvas.width;
+        }
+      }
+    }
+
+    window.addEventListener('resize', resize);
+    resize();
+    initFlakes();
+    window.requestAnimationFrame(draw);
+  }
+
+  function createSparkles() {
+    if (prefersReducedMotion()) return;
+    let activeSparkles = 0;
+    const MAX_SPARKLES = 14;
+
+    function spawnSparkle(event) {
+      if (activeSparkles >= MAX_SPARKLES) return;
+      const sparkle = document.createElement('span');
+      sparkle.className = 'holiday-sparkle';
+      sparkle.style.left = `${event.clientX}px`;
+      sparkle.style.top = `${event.clientY}px`;
+      sparkle.style.setProperty('--sparkle-hue', Math.floor(Math.random() * 30) + 10);
+      document.body.appendChild(sparkle);
+      activeSparkles += 1;
+      sparkle.addEventListener('animationend', () => {
+        sparkle.remove();
+        activeSparkles -= 1;
+      });
+    }
+
+    document.addEventListener('pointermove', spawnSparkle);
+  }
+
+  function getCountdownMessage() {
+    const lang = getCurrentLanguage();
+    const now = new Date();
+    const target = new Date(now.getFullYear(), 11, 24, 0, 0, 0, 0);
+    const diffDays = Math.ceil((target - now) / (1000 * 60 * 60 * 24));
+    const isBefore = diffDays > 0;
+
+    if (isBefore) {
+      return lang === 'en'
+        ? `Countdown to Christmas Eve: ${diffDays} ${diffDays === 1 ? 'day' : 'days'}`
+        : `Cuenta regresiva para Nochebuena: ${diffDays} ${diffDays === 1 ? 'día' : 'días'}`;
+    }
+
+    return lang === 'en'
+      ? 'Happy Holidays! Seasonal treats available until Dec 27.'
+      : '¡Felices fiestas! Las sorpresas continúan hasta el 27 de diciembre.';
+  }
+
+  function addCountdownRibbon() {
+    const ribbon = document.createElement('div');
+    ribbon.className = 'holiday-ribbon';
+    ribbon.role = 'status';
+    ribbon.textContent = getCountdownMessage();
+    document.body.prepend(ribbon);
+  }
+
+  function addHolidayToast() {
+    const toast = document.createElement('div');
+    toast.className = 'holiday-toast';
+    const lang = getCurrentLanguage();
+    const heading = document.createElement('strong');
+    heading.textContent = lang === 'en' ? 'Holiday hours' : 'Horarios festivos';
+    const message = document.createElement('span');
+    message.textContent = lang === 'en'
+      ? 'Ask your server about special closures and seasonal dishes.'
+      : 'Pregunta por cierres especiales y platillos de temporada.';
+    toast.appendChild(heading);
+    toast.appendChild(message);
+    document.body.appendChild(toast);
+  }
+
+  function createHolidayActionItem(list) {
+    const existing = list.querySelector('[data-holiday-action]');
+    if (existing) return;
+    const lang = getCurrentLanguage();
+    const li = document.createElement('li');
+    li.className = 'home-actions__item';
+    li.dataset.holidayAction = 'true';
+
+    const link = document.createElement('a');
+    link.className = 'home-actions__link home-actions__link--primary holiday-action';
+    link.href = 'menu.html#holiday';
+    link.dataset.soundId = 'menu-cta';
+
+    const icon = document.createElement('span');
+    icon.className = 'home-actions__icon';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.innerHTML = '<svg fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">\
+<path d="M16 4l2.47 7.6H26l-6.18 4.5 2.36 7.3L16 19.5l-6.18 3.9 2.36-7.3L6 11.6h7.53L16 4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>\
+</svg>';
+
+    const content = document.createElement('span');
+    content.className = 'home-actions__content';
+
+    const title = document.createElement('span');
+    title.className = 'home-actions__title';
+    title.textContent = lang === 'en' ? 'Holiday Specials' : 'Especiales Navideños';
+    title.dataset.i18nEn = 'Holiday Specials';
+    title.dataset.i18nEs = 'Especiales Navideños';
+
+    const description = document.createElement('span');
+    description.className = 'home-actions__description';
+    description.textContent = lang === 'en'
+      ? 'Try limited-time dishes and festive drinks.'
+      : 'Prueba platillos y bebidas festivas por tiempo limitado.';
+    description.dataset.i18nEn = 'Try limited-time dishes and festive drinks.';
+    description.dataset.i18nEs = 'Prueba platillos y bebidas festivas por tiempo limitado.';
+
+    content.appendChild(title);
+    content.appendChild(description);
+    link.appendChild(icon);
+    link.appendChild(content);
+    li.appendChild(link);
+    list.appendChild(li);
+  }
+
+  function addHolidayActionTile() {
+    const list = document.querySelector('[data-home-actions]');
+    if (!list) return;
+
+    const attemptInsert = () => createHolidayActionItem(list);
+
+    if (list.getAttribute('data-home-actions-loaded') === 'true') {
+      attemptInsert();
+      return;
+    }
+
+    const observer = new MutationObserver(mutations => {
+      for (const mutation of mutations) {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-home-actions-loaded') {
+          if (list.getAttribute('data-home-actions-loaded') === 'true') {
+            attemptInsert();
+            observer.disconnect();
+            return;
+          }
+        }
+      }
+    });
+
+    observer.observe(list, { attributes: true });
+  }
+
+  function initSeasonalMode() {
+    if (!isSeasonActive()) {
+      return;
+    }
+
+    applySeasonalPalette();
+    createLightString();
+    createSnowLayer();
+    createSparkles();
+    addCountdownRibbon();
+    addHolidayToast();
+    addHolidayActionTile();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initSeasonalMode);
+  } else {
+    initSeasonalMode();
+  }
+})();

--- a/styles/main.css
+++ b/styles/main.css
@@ -19,6 +19,32 @@
   --home-background-blend-mode:normal;
   --home-background-position:center 8%;
   --home-background-position-mobile:center 18%;
+  --holiday-accent:#C41E3A;
+  --holiday-accent-2:#F5B841;
+  --holiday-accent-soft:rgba(196, 30, 58, 0.12);
+  --holiday-glow:0 18px 38px rgba(196, 30, 58, 0.35);
+}
+
+:root[data-seasonal-holiday="true"] {
+  --gereni-brown:#7A1F2A;
+  --gereni-green:#3F6F4A;
+  --gereni-cream:#F8F2E7;
+  --gereni-card:#FFFFFF;
+  --gereni-text:#201312;
+  --home-background-overlay:linear-gradient(rgba(248,242,231,0.72), rgba(248,242,231,0.92));
+  --home-highlight-card-glow:rgba(245,184,65,0.28);
+  --home-highlight-card-glow-secondary:rgba(62,143,102,0.28);
+}
+
+:root[data-seasonal-holiday="true"][data-theme="dark"] {
+  --gereni-brown:#F7D7C7;
+  --gereni-green:#8EC6A4;
+  --gereni-cream:#0E0908;
+  --gereni-card:#161412;
+  --gereni-text:#F4EAE4;
+  --home-highlight-card:rgba(25,22,19,0.9);
+  --home-highlight-card-border:rgba(244,234,228,0.18);
+  --home-background-overlay:linear-gradient(rgba(14,9,8,0.82), rgba(14,9,8,0.92));
 }
 
 :root[data-theme="dark"] {
@@ -104,6 +130,51 @@ body.inicio {
   background-color:transparent;
 }
 
+.holiday-ribbon {
+  position:sticky;
+  top:0;
+  z-index:12;
+  padding:0.65rem 1rem;
+  background:linear-gradient(90deg, rgba(196,30,58,0.12), rgba(245,184,65,0.16));
+  color:var(--gereni-text);
+  font-weight:600;
+  letter-spacing:0.02em;
+  border-bottom:1px solid rgba(196,30,58,0.24);
+  box-shadow:var(--holiday-glow, 0 10px 26px rgba(0,0,0,0.22));
+}
+
+.holiday-toast {
+  position:fixed;
+  right:clamp(0.75rem, 3vw, 1.5rem);
+  bottom:clamp(0.75rem, 3vw, 1.5rem);
+  z-index:18;
+  display:flex;
+  flex-direction:column;
+  gap:0.25rem;
+  padding:0.85rem 1rem;
+  background:rgba(33,26,24,0.88);
+  color:#fffaf5;
+  border-radius:14px;
+  box-shadow:0 12px 32px rgba(0,0,0,0.35);
+  border:1px solid rgba(255,255,255,0.06);
+  backdrop-filter:blur(10px);
+  -webkit-backdrop-filter:blur(10px);
+}
+
+:root[data-theme="light"] .holiday-toast {
+  background:rgba(255,255,255,0.9);
+  color:#2c1f1d;
+  border-color:rgba(196,30,58,0.28);
+}
+
+.holiday-toast strong {
+  font-size:0.95rem;
+}
+
+.holiday-toast span {
+  font-size:0.9rem;
+}
+
 body.inicio::before {
   content:"";
   position:fixed;
@@ -168,6 +239,46 @@ body.inicio main {
   gap:clamp(1.5rem, 5vw, 2.75rem);
   padding-inline:clamp(0.5rem, 3vw, 1.5rem);
   box-sizing:border-box;
+}
+
+.holiday-lights {
+  position:absolute;
+  top:-1.2rem;
+  left:0;
+  right:0;
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(16px, 1fr));
+  gap:0.3rem;
+  padding-inline:1rem;
+  pointer-events:none;
+  z-index:4;
+}
+
+.holiday-lights::after {
+  content:"";
+  position:absolute;
+  top:0.7rem;
+  left:0.4rem;
+  right:0.4rem;
+  height:2px;
+  background:linear-gradient(90deg, rgba(196,30,58,0.6), rgba(245,184,65,0.7));
+  opacity:0.8;
+}
+
+.holiday-lights__bulb {
+  width:16px;
+  height:22px;
+  background:var(--bulb-color, #FAD643);
+  border-radius:50% 50% 40% 40%;
+  box-shadow:0 8px 18px rgba(0,0,0,0.18);
+  margin:0 auto;
+  transform-origin:50% -8px;
+  animation:holidayTwinkle 2.8s ease-in-out infinite;
+}
+
+@keyframes holidayTwinkle {
+  0%, 100% { opacity:0.9; transform:rotate(-2deg); }
+  50% { opacity:0.55; transform:rotate(2deg) scale(1.04); }
 }
 
 @media (min-width: 900px) {
@@ -688,6 +799,30 @@ body.inicio main {
 
 .home-actions__link--social {
   text-transform:none;
+}
+
+.holiday-action {
+  position:relative;
+  overflow:hidden;
+  border:1px solid rgba(245,184,65,0.5);
+  box-shadow:var(--holiday-glow, 0 16px 28px rgba(0,0,0,0.25));
+}
+
+.holiday-action::before {
+  content:"";
+  position:absolute;
+  inset:0;
+  background:linear-gradient(135deg, rgba(196,30,58,0.14), rgba(245,184,65,0.16));
+  opacity:1;
+  pointer-events:none;
+}
+
+.holiday-action .home-actions__content {
+  position:relative;
+}
+
+.holiday-action .home-actions__title {
+  color:var(--holiday-accent, #C41E3A);
 }
 
 .home-social__icon {
@@ -1523,6 +1658,33 @@ footer {
   padding:1.5rem;
   color:var(--gereni-muted);
   font-size:0.9rem;
+}
+
+.holiday-snow {
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  z-index:0;
+  mix-blend-mode:screen;
+  opacity:0.8;
+}
+
+.holiday-sparkle {
+  position:fixed;
+  width:10px;
+  height:10px;
+  border-radius:50%;
+  pointer-events:none;
+  background:conic-gradient(from 45deg, hsla(var(--sparkle-hue, 16), 82%, 65%, 0.95), hsla(var(--sparkle-hue, 16), 72%, 72%, 0.4));
+  filter:drop-shadow(0 0 6px rgba(255,255,255,0.8));
+  animation:sparklePop 900ms ease-out forwards;
+  z-index:20;
+}
+
+@keyframes sparklePop {
+  0% { transform:scale(0.6); opacity:0.9; }
+  60% { transform:scale(1.4); opacity:1; }
+  100% { transform:scale(0.4); opacity:0; }
 }
 
 /* Hero graphic */


### PR DESCRIPTION
## Summary
- enable seasonal mode script for post-Thanksgiving through Dec 27 with manual overrides
- add festive visuals (lights, snow, sparkles) and content touches (ribbon, toast, holiday CTA)
- apply holiday palette variables to refresh homepage accent colors

## Plan
1. Add seasonal detection and override hooks.
2. Layer in holiday visuals (lights, snow, sparkles) respecting reduced-motion.
3. Surface seasonal content elements (ribbon, toast, CTA) on homepage.
4. Update styles with holiday palette and effects.
5. Verify home action rendering and note any test limitations.

## Changes
- index.html
- scripts/seasonalMode.js
- styles/main.css

## Verification
Commands:
```
npm run test:home-actions
```
Evidence:
- npm unavailable in environment (`bash: command not found: npm`).

## Risks & Mitigations
- Seasonal visuals could distract some users → respects prefers-reduced-motion and allows disable via query override.
- Extra DOM elements could overlap content → positioned sticky/fixed with pointer-events: none where appropriate.

## Follow-ups
- Add screenshot of seasonal mode once deployed to ensure visuals align with brand.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334051b4908323a8f569ff2985b148)

## Summary by Sourcery

Enable a holiday seasonal mode on the homepage that activates around the winter holidays and decorates the page with festive visuals and content.

New Features:
- Introduce a seasonal mode script that automatically detects the holiday window with manual query/localStorage overrides.
- Add holiday-themed homepage elements including a countdown ribbon, toast message about holiday hours, decorative lights, snow, sparkles, and a holiday specials action tile.
- Apply holiday color palette variables and styles for light and dark themes via a seasonal data attribute on the document.

Enhancements:
- Hook the new seasonal mode script into the homepage by loading it from index.html.